### PR TITLE
feat: responsive redesign of all frontend pages

### DIFF
--- a/front/src/pages/Unauthorized.tsx
+++ b/front/src/pages/Unauthorized.tsx
@@ -9,11 +9,11 @@ export default function Unauthorized() {
     const navigate = useNavigate();
 
     return (
-        <div className="flex min-h-screen items-center justify-center bg-gray-50">
-            <div className="text-center">
+        <div className="flex min-h-screen items-center justify-center bg-stone-50 px-4">
+            <div className="text-center max-w-md w-full">
                 <div className="mb-8">
                     <svg
-                        className="mx-auto h-24 w-24 text-red-500"
+                        className="mx-auto h-20 w-20 sm:h-24 sm:w-24 text-red-500"
                         fill="none"
                         viewBox="0 0 24 24"
                         stroke="currentColor"
@@ -27,16 +27,16 @@ export default function Unauthorized() {
                         />
                     </svg>
                 </div>
-                <h1 className="mb-4 text-4xl font-bold text-gray-900">
+                <h1 className="mb-4 text-3xl sm:text-4xl font-bold text-stone-900">
                     Acesso Negado
                 </h1>
-                <p className="mb-8 text-lg text-gray-600">
+                <p className="mb-6 sm:mb-8 text-base sm:text-lg text-stone-600">
                     Você não tem permissão para acessar este recurso.
                 </p>
-                <p className="mb-8 text-sm text-gray-500">
+                <p className="mb-6 sm:mb-8 text-sm text-stone-500">
                     Entre em contato com o administrador se você acredita que deveria ter acesso.
                 </p>
-                <div className="flex gap-4 justify-center">
+                <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
                     <Button
                         onClick={() => navigate(-1)}
                         variant="outline"

--- a/front/src/pages/activities/Activities.tsx
+++ b/front/src/pages/activities/Activities.tsx
@@ -96,7 +96,7 @@ export default function Activities() {
 
       {/* ── stats ── */}
       {!loading && activities.length > 0 && (
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           <StatCard label="Pendentes" value={pendingCount} icon={Clock} />
           <StatCard
             label="Atrasadas"

--- a/front/src/pages/activitiesDetails/ActivitiesDetails.tsx
+++ b/front/src/pages/activitiesDetails/ActivitiesDetails.tsx
@@ -1,12 +1,3 @@
-import { Button } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/table";
 import { getProblemById } from "@/services/ProblemsServices";
 import {
   getSubmissionsByActivityId,
@@ -17,14 +8,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import {
   Calendar,
-  FileText,
   Upload,
   XCircle,
   ArrowLeft,
-  RefreshCw,
   User,
   Target,
-  ArrowRight,
   Loader2,
 } from "lucide-react";
 import { CodeSubmissionComponent } from "../../components/CodeSubmission";
@@ -33,49 +21,8 @@ import { RichTextViewer } from "@/components/RichTextEditor";
 import { StatCard } from "@/components/StatCard";
 import { SectionCard } from "@/components/SectionCard";
 import { EmptyState } from "@/components/EmptyState";
-import {
-  StatusBadge,
-  submissionStatusConfig,
-  type SubmissionStatusKey,
-} from "@/components/StatusBadge";
-
-/* ── helpers ────────────────────────────────────────── */
-
-function formatDate(dateString: string) {
-  const date = new Date(dateString);
-
-  if (!dateString || isNaN(date.getTime())) {
-    return { formatted: "Data indisponível", relative: "", isOverdue: false };
-  }
-
-  const now = new Date();
-  const diffTime = date.getTime() - now.getTime();
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-  const formatted = date.toLocaleDateString("pt-BR", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-
-  let relative = "";
-  let isOverdue = false;
-
-  if (diffDays < 0) {
-    relative = `${Math.abs(diffDays)} dias atrás`;
-    isOverdue = true;
-  } else if (diffDays === 0) {
-    relative = "Hoje";
-  } else if (diffDays === 1) {
-    relative = "Amanhã";
-  } else {
-    relative = `Em ${diffDays} dias`;
-  }
-
-  return { formatted, relative, isOverdue };
-}
+import { SubmissionsHistory } from "./SubmissionsHistory";
+import { formatDate } from "./utils";
 
 /* ── main component ─────────────────────────────────── */
 
@@ -128,7 +75,7 @@ export default function ActivitiesDetails() {
 
       setActivitySubmissions(data);
     } catch (error) {
-      console.error("Erro ao buscar submissões da atividade:", error);
+      console.error("Erro ao buscar submiss\u00f5es da atividade:", error);
       setActivitySubmissions([]);
     } finally {
       setLocalLoading(false);
@@ -180,7 +127,7 @@ export default function ActivitiesDetails() {
       setActivitySubmissions((prev) => [newSubmission, ...prev]);
       updateSubmissions();
 
-      pushNotification("Submissão enviada! Aguarde a avaliação.", "success");
+      pushNotification("Submiss\u00e3o enviada! Aguarde a avalia\u00e7\u00e3o.", "success");
       setHighlightedId(newSubmission.id);
       setTimeout(() => setHighlightedId(null), 3000);
       setTimeout(() => historyRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 100);
@@ -188,7 +135,7 @@ export default function ActivitiesDetails() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const axiosError = error as any;
       const backendMsg = axiosError?.response?.data?.message;
-      pushNotification(backendMsg || "Erro ao submeter o código. Tente novamente.", "error");
+      pushNotification(backendMsg || "Erro ao submeter o c\u00f3digo. Tente novamente.", "error");
       console.error("Error submitting code:", error);
     } finally {
       setSubmitting(false);
@@ -198,7 +145,7 @@ export default function ActivitiesDetails() {
   /* ── loading state ── */
   if (loading || (selectedActivity && !selectedProblem && localLoading)) {
     return (
-      <div className="max-w-5xl mx-auto px-6 py-16">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-16">
         <div className="bg-stone-50 border border-stone-200 rounded-xl p-12 flex flex-col items-center gap-4">
           <Loader2 className="w-6 h-6 animate-spin text-teal-600" />
           <p className="text-sm text-stone-500 font-medium">Carregando detalhes da atividade...</p>
@@ -210,11 +157,11 @@ export default function ActivitiesDetails() {
   /* ── activity not found ── */
   if (selectedActivity === undefined) {
     return (
-      <div className="max-w-5xl mx-auto px-6 py-16">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-16">
         <EmptyState
           icon={XCircle}
-          title="Atividade não encontrada"
-          description="A atividade que você está procurando não existe ou foi removida."
+          title="Atividade n\u00e3o encontrada"
+          description="A atividade que voc\u00ea est\u00e1 procurando n\u00e3o existe ou foi removida."
           action={{
             label: "Voltar para Atividades",
             onClick: () => navigate("/activities"),
@@ -228,11 +175,11 @@ export default function ActivitiesDetails() {
   /* ── problem not found ── */
   if (selectedProblem === undefined) {
     return (
-      <div className="max-w-5xl mx-auto px-6 py-16">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-16">
         <EmptyState
           icon={XCircle}
-          title="Problema não encontrado"
-          description="O problema associado a esta atividade não foi encontrado."
+          title="Problema n\u00e3o encontrado"
+          description="O problema associado a esta atividade n\u00e3o foi encontrado."
           action={{
             label: "Voltar para Atividades",
             onClick: () => navigate("/activities"),
@@ -246,7 +193,7 @@ export default function ActivitiesDetails() {
   const dueDate = formatDate(selectedActivity.dueDate);
 
   return (
-    <div className="max-w-5xl mx-auto px-6 py-10 space-y-8">
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10 space-y-6 sm:space-y-8">
 
       {/* ── back link + header ── */}
       <div>
@@ -259,12 +206,12 @@ export default function ActivitiesDetails() {
         </button>
 
         <p className="text-sm text-stone-400 font-medium">Atividade #{selectedActivity.id}</p>
-        <h1 className="text-2xl font-bold text-stone-900 tracking-tight mt-1">
+        <h1 className="text-xl sm:text-2xl font-bold text-stone-900 tracking-tight mt-1">
           {selectedProblem.title}
         </h1>
       </div>
 
-      {/* ── stat cards (prazo + submissões) ── */}
+      {/* ── stat cards (prazo + submiss\u00f5es) ── */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <StatCard
           label={dueDate.relative}
@@ -273,7 +220,7 @@ export default function ActivitiesDetails() {
           accent={dueDate.isOverdue}
         />
         <StatCard
-          label="Submissões"
+          label="Submiss\u00f5es"
           value={localLoading ? <Loader2 className="w-6 h-6 animate-spin text-teal-600" /> : activitySubmissions.length}
           icon={User}
         />
@@ -281,106 +228,31 @@ export default function ActivitiesDetails() {
 
       {/* ── enunciado ── */}
       <SectionCard title="Enunciado" icon={Target}>
-        <div className="p-6">
+        <div className="px-3 py-4 sm:px-6 sm:py-6">
           <RichTextViewer
             value={selectedProblem.statement}
-            className="text-stone-700 leading-relaxed"
+            className="text-sm sm:text-base text-stone-700 leading-relaxed"
           />
         </div>
       </SectionCard>
 
-      {/* ── nova submissão ── */}
-      <SectionCard title="Nova Submissão" icon={Upload}>
+      {/* ── nova submiss\u00e3o ── */}
+      <SectionCard title="Nova Submiss\u00e3o" icon={Upload}>
         <CodeSubmissionComponent
           onSubmit={(code) => handleSubmit(code, selectedActivity.id)}
           disabled={submitDisabled}
         />
       </SectionCard>
 
-      {/* ── histórico de submissões ── */}
+      {/* ── hist\u00f3rico de submiss\u00f5es ── */}
       <div ref={historyRef} />
-      <SectionCard
-        title="Histórico de Submissões"
-        icon={FileText}
-        action={
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => selectedActivity && fetchSubmissions(selectedActivity)}
-            disabled={localLoading}
-          >
-            <RefreshCw className={`w-4 h-4 ${localLoading ? 'animate-spin' : ''}`} />
-            {localLoading ? 'Atualizando...' : 'Atualizar'}
-          </Button>
-        }
-      >
-        <div className="p-6">
-          {localLoading ? (
-            <div className="flex flex-col items-center gap-4 py-8">
-              <Loader2 className="w-6 h-6 animate-spin text-teal-600" />
-              <p className="text-sm text-stone-500 font-medium">Carregando submissões...</p>
-            </div>
-          ) : activitySubmissions.length === 0 ? (
-            <EmptyState
-              icon={FileText}
-              title="Nenhuma submissão para esta atividade"
-              description="Use o editor acima para enviar seu código."
-            />
-          ) : (
-            <div className="overflow-hidden rounded-lg border border-stone-200">
-              <Table>
-                <TableHeader>
-                  <TableRow className="bg-stone-50 hover:bg-stone-50">
-                    <TableHead className="font-semibold text-stone-700 text-xs">
-                      Data de Submissão
-                    </TableHead>
-                    <TableHead className="font-semibold text-stone-700 text-xs">
-                      Status
-                    </TableHead>
-                    <TableHead className="w-12"></TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {activitySubmissions.map((submission: Submission) => {
-                    const submissionDate = formatDate(submission.dateSubmitted);
-                    const statusKey = submission.status as SubmissionStatusKey;
-                    const statusCfg = submissionStatusConfig[statusKey] || submissionStatusConfig.pending;
-                    return (
-                      <TableRow
-                        key={submission.id}
-                        onClick={() => redirectToSubmission(submission)}
-                        className={`cursor-pointer hover:bg-stone-50 transition-all duration-500 group ${
-                          highlightedId === submission.id ? "bg-teal-50 ring-1 ring-teal-200" : ""
-                        }`}
-                      >
-                        <TableCell>
-                          <div className="flex flex-col">
-                            <span className="text-stone-800 text-sm font-medium">
-                              {submissionDate.formatted}
-                            </span>
-                            <span className="text-xs text-stone-400">
-                              {submissionDate.relative}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <StatusBadge
-                            label={statusCfg.label}
-                            className={statusCfg.className}
-                          />
-                        </TableCell>
-                        <TableCell>
-                          <ArrowRight className="w-4 h-4 text-stone-300 group-hover:text-teal-600 transition-colors" />
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </div>
-      </SectionCard>
+      <SubmissionsHistory
+        submissions={activitySubmissions}
+        highlightedId={highlightedId}
+        loading={localLoading}
+        onRefresh={() => selectedActivity && fetchSubmissions(selectedActivity)}
+        onSubmissionClick={redirectToSubmission}
+      />
     </div>
   );
 }

--- a/front/src/pages/activitiesDetails/SubmissionsHistory.tsx
+++ b/front/src/pages/activitiesDetails/SubmissionsHistory.tsx
@@ -1,0 +1,171 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/table";
+import { Button } from "@/components/ui/button";
+import { SectionCard } from "@/components/SectionCard";
+import { EmptyState } from "@/components/EmptyState";
+import {
+  StatusBadge,
+  submissionStatusConfig,
+  type SubmissionStatusKey,
+} from "@/components/StatusBadge";
+import type { Submission } from "@/types";
+import {
+  FileText,
+  RefreshCw,
+  ArrowRight,
+  Loader2,
+} from "lucide-react";
+import { formatDate } from "./utils";
+
+interface SubmissionsHistoryProps {
+  submissions: Submission[];
+  highlightedId: number | null;
+  loading: boolean;
+  onRefresh: () => void;
+  onSubmissionClick: (submission: Submission) => void;
+}
+
+export function SubmissionsHistory({
+  submissions,
+  highlightedId,
+  loading,
+  onRefresh,
+  onSubmissionClick,
+}: SubmissionsHistoryProps) {
+  return (
+    <SectionCard
+      title="Hist\u00f3rico de Submiss\u00f5es"
+      icon={FileText}
+      action={
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRefresh}
+          disabled={loading}
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? "animate-spin" : ""}`} />
+          {loading ? "Atualizando..." : "Atualizar"}
+        </Button>
+      }
+    >
+      <div className="px-3 py-4 sm:px-6 sm:py-6">
+        {loading ? (
+          <div className="flex flex-col items-center gap-4 py-8">
+            <Loader2 className="w-6 h-6 animate-spin text-teal-600" />
+            <p className="text-sm text-stone-500 font-medium">
+              Carregando submiss\u00f5es...
+            </p>
+          </div>
+        ) : submissions.length === 0 ? (
+          <EmptyState
+            icon={FileText}
+            title="Nenhuma submiss\u00e3o para esta atividade"
+            description="Use o editor acima para enviar seu c\u00f3digo."
+          />
+        ) : (
+          <>
+            {/* Desktop table */}
+            <div className="hidden sm:block overflow-hidden rounded-lg border border-stone-200">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-stone-50 hover:bg-stone-50">
+                    <TableHead className="font-semibold text-stone-700 text-xs">
+                      Data de Submiss\u00e3o
+                    </TableHead>
+                    <TableHead className="font-semibold text-stone-700 text-xs">
+                      Status
+                    </TableHead>
+                    <TableHead className="w-12" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {submissions.map((submission) => {
+                    const submissionDate = formatDate(submission.dateSubmitted);
+                    const statusKey = submission.status as SubmissionStatusKey;
+                    const statusCfg =
+                      submissionStatusConfig[statusKey] ||
+                      submissionStatusConfig.pending;
+                    return (
+                      <TableRow
+                        key={submission.id}
+                        onClick={() => onSubmissionClick(submission)}
+                        className={`cursor-pointer hover:bg-stone-50 transition-all duration-500 group ${
+                          highlightedId === submission.id
+                            ? "bg-teal-50 ring-1 ring-teal-200"
+                            : ""
+                        }`}
+                      >
+                        <TableCell>
+                          <div className="flex flex-col">
+                            <span className="text-stone-800 text-sm font-medium">
+                              {submissionDate.formatted}
+                            </span>
+                            <span className="text-xs text-stone-400">
+                              {submissionDate.relative}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <StatusBadge
+                            label={statusCfg.label}
+                            className={statusCfg.className}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <ArrowRight className="w-4 h-4 text-stone-300 group-hover:text-teal-600 transition-colors" />
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+
+            {/* Mobile card list */}
+            <div className="flex flex-col gap-2 sm:hidden">
+              {submissions.map((submission) => {
+                const submissionDate = formatDate(submission.dateSubmitted);
+                const statusKey = submission.status as SubmissionStatusKey;
+                const statusCfg =
+                  submissionStatusConfig[statusKey] ||
+                  submissionStatusConfig.pending;
+                return (
+                  <button
+                    key={submission.id}
+                    type="button"
+                    onClick={() => onSubmissionClick(submission)}
+                    className={`flex items-center justify-between rounded-lg border px-3 py-3 text-left transition-all duration-500 ${
+                      highlightedId === submission.id
+                        ? "border-teal-200 bg-teal-50"
+                        : "border-stone-200 bg-white hover:bg-stone-50"
+                    }`}
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span className="text-sm font-medium text-stone-800">
+                        {submissionDate.formatted}
+                      </span>
+                      <span className="text-xs text-stone-400">
+                        {submissionDate.relative}
+                      </span>
+                      <StatusBadge
+                        label={statusCfg.label}
+                        className={statusCfg.className}
+                      />
+                    </div>
+                    <ArrowRight className="w-4 h-4 shrink-0 text-stone-300" />
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </SectionCard>
+  );
+}

--- a/front/src/pages/activitiesDetails/utils.ts
+++ b/front/src/pages/activitiesDetails/utils.ts
@@ -1,0 +1,35 @@
+export function formatDate(dateString: string) {
+  const date = new Date(dateString);
+
+  if (!dateString || isNaN(date.getTime())) {
+    return { formatted: "Data indispon\u00edvel", relative: "", isOverdue: false };
+  }
+
+  const now = new Date();
+  const diffTime = date.getTime() - now.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  const formatted = date.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  let relative = "";
+  let isOverdue = false;
+
+  if (diffDays < 0) {
+    relative = `${Math.abs(diffDays)} dias atr\u00e1s`;
+    isOverdue = true;
+  } else if (diffDays === 0) {
+    relative = "Hoje";
+  } else if (diffDays === 1) {
+    relative = "Amanh\u00e3";
+  } else {
+    relative = `Em ${diffDays} dias`;
+  }
+
+  return { formatted, relative, isOverdue };
+}

--- a/front/src/pages/changePassword/ChangePassword.tsx
+++ b/front/src/pages/changePassword/ChangePassword.tsx
@@ -1,12 +1,12 @@
 import { changePassword } from "@/services/ChangePasswordService";
 import { useState } from "react";
-import showIcon from "@/assets/icons/password-show.svg";
-import hideIcon from "@/assets/icons/password-hide.svg";
 import { useNavigate } from "react-router";
 import axios from "axios";
 import Notification from "@/components/Notification";
-import { ArrowLeft, KeyRound, Loader2 } from "lucide-react";
-import { SectionCard } from "@/components/SectionCard";
+import { ArrowLeft, Eye, EyeOff, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 
 export default function ChangePassword() {
     const [showCurrentPassword, setShowCurrentPassword] = useState(false);
@@ -87,147 +87,153 @@ export default function ChangePassword() {
     }
 
     return (
-        <div className="max-w-lg mx-auto px-6 py-10 space-y-8">
+        <div className="min-h-screen flex items-center justify-center px-4 bg-stone-50">
             {error && <Notification type="error" message={error} onClose={() => setError(null)} />}
             {success && <Notification type="success" message={success} onClose={() => setSuccess(null)} />}
 
-            {/* ── header ── */}
-            <div>
-                <button
-                    type="button"
-                    onClick={() => navigate(-1)}
-                    className="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors mb-4"
-                >
-                    <ArrowLeft className="w-4 h-4" />
-                    Voltar
-                </button>
-
-                <h1 className="text-2xl font-bold text-zinc-900 tracking-tight">Alterar Senha</h1>
-                <p className="text-zinc-400 text-sm mt-1">Atualize sua senha para manter a conta segura</p>
-            </div>
-
-            {/* ── form ── */}
-            <SectionCard title="Nova senha" icon={KeyRound}>
-                <form onSubmit={handleSubmit} className="p-6 space-y-5">
-
-                    {/* Senha Atual */}
-                    <div>
-                        <label htmlFor="currentPassword" className="block text-sm font-medium text-zinc-700 mb-1.5">
-                            Senha Atual
-                        </label>
-                        <div className="relative">
-                            <input
-                                type={showCurrentPassword ? "text" : "password"}
-                                id="currentPassword"
-                                className={`block w-full border rounded-lg px-3 py-2 pr-10 text-sm transition-all focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                                    currentPasswordError ? "border-red-300 bg-red-50/50" : "border-zinc-200 bg-white"
-                                }`}
-                                required
-                                value={currentPassword}
-                                onChange={e => setCurrentPassword(e.target.value)}
-                                onBlur={e => setCurrentPasswordError(validateCurrentPassword(e.target.value))}
-                            />
-                            <button
-                                type="button"
-                                className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors"
-                                onClick={() => setShowCurrentPassword(v => !v)}
-                                title={showCurrentPassword ? "Ocultar senha" : "Mostrar senha"}
-                            >
-                                <img
-                                    src={showCurrentPassword ? hideIcon : showIcon}
-                                    alt={showCurrentPassword ? "Ocultar senha" : "Mostrar senha"}
-                                    width={18}
-                                    height={18}
-                                />
-                            </button>
-                        </div>
-                        {currentPasswordError && (
-                            <p className="text-red-600 text-xs mt-1.5">{currentPasswordError}</p>
-                        )}
-                    </div>
-
-                    {/* Nova Senha */}
-                    <div>
-                        <label htmlFor="newPassword" className="block text-sm font-medium text-zinc-700 mb-1.5">
-                            Nova Senha
-                        </label>
-                        <div className="relative">
-                            <input
-                                type={showNewPassword ? "text" : "password"}
-                                id="newPassword"
-                                className={`block w-full border rounded-lg px-3 py-2 pr-10 text-sm transition-all focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                                    newPasswordError ? "border-red-300 bg-red-50/50" : "border-zinc-200 bg-white"
-                                }`}
-                                required
-                                value={newPassword}
-                                onChange={e => setNewPassword(e.target.value)}
-                                onBlur={e => setNewPasswordError(validateNewPassword(e.target.value))}
-                            />
-                            <button
-                                type="button"
-                                className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors"
-                                onClick={() => setShowNewPassword(v => !v)}
-                                title={showNewPassword ? "Ocultar senha" : "Mostrar senha"}
-                            >
-                                <img
-                                    src={showNewPassword ? hideIcon : showIcon}
-                                    alt={showNewPassword ? "Ocultar senha" : "Mostrar senha"}
-                                    width={18}
-                                    height={18}
-                                />
-                            </button>
-                        </div>
-                        {newPasswordError && (
-                            <p className="text-red-600 text-xs mt-1.5">{newPasswordError}</p>
-                        )}
-                    </div>
-
-                    {/* Confirmar Nova Senha */}
-                    <div>
-                        <label htmlFor="confirmPassword" className="block text-sm font-medium text-zinc-700 mb-1.5">
-                            Confirmar Nova Senha
-                        </label>
-                        <div className="relative">
-                            <input
-                                type={showConfirmPassword ? "text" : "password"}
-                                id="confirmPassword"
-                                className={`block w-full border rounded-lg px-3 py-2 pr-10 text-sm transition-all focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                                    confirmPasswordError ? "border-red-300 bg-red-50/50" : "border-zinc-200 bg-white"
-                                }`}
-                                required
-                                value={confirmPassword}
-                                onChange={e => setConfirmPassword(e.target.value)}
-                                onBlur={e => setConfirmPasswordError(validateConfirmPassword(e.target.value, newPassword))}
-                            />
-                            <button
-                                type="button"
-                                className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors"
-                                onClick={() => setShowConfirmPassword(v => !v)}
-                                title={showConfirmPassword ? "Ocultar senha" : "Mostrar senha"}
-                            >
-                                <img
-                                    src={showConfirmPassword ? hideIcon : showIcon}
-                                    alt={showConfirmPassword ? "Ocultar senha" : "Mostrar senha"}
-                                    width={18}
-                                    height={18}
-                                />
-                            </button>
-                        </div>
-                        {confirmPasswordError && (
-                            <p className="text-red-600 text-xs mt-1.5">{confirmPasswordError}</p>
-                        )}
-                    </div>
-
+            <div className="w-full max-w-md space-y-6">
+                {/* Header */}
+                <div>
                     <button
-                        type="submit"
-                        disabled={submitting}
-                        className="w-full flex items-center justify-center gap-2 bg-teal-600 hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg text-white text-sm font-medium py-2.5 transition-colors"
+                        type="button"
+                        onClick={() => navigate(-1)}
+                        className="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors mb-4"
                     >
-                        {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
-                        {submitting ? "Alterando..." : "Alterar Senha"}
+                        <ArrowLeft className="w-4 h-4" />
+                        Voltar
                     </button>
-                </form>
-            </SectionCard>
+
+                    <h1 className="text-2xl font-bold text-stone-900 tracking-tight">Alterar Senha</h1>
+                    <p className="text-stone-400 text-sm mt-1">Atualize sua senha para manter a conta segura</p>
+                </div>
+
+                {/* Form card */}
+                <div className="rounded-xl border border-stone-200 bg-white p-4 sm:p-6">
+                    <form onSubmit={handleSubmit} className="space-y-5">
+
+                        {/* Senha Atual */}
+                        <div>
+                            <Label htmlFor="currentPassword" className="mb-1.5 text-stone-700">
+                                Senha Atual
+                            </Label>
+                            <div className="relative">
+                                <Input
+                                    type={showCurrentPassword ? "text" : "password"}
+                                    id="currentPassword"
+                                    className={`pr-10 ${
+                                        currentPasswordError ? "border-red-400 ring-2 ring-red-100" : ""
+                                    }`}
+                                    aria-invalid={currentPasswordError ? true : undefined}
+                                    required
+                                    value={currentPassword}
+                                    onChange={e => setCurrentPassword(e.target.value)}
+                                    onBlur={e => setCurrentPasswordError(validateCurrentPassword(e.target.value))}
+                                />
+                                <button
+                                    type="button"
+                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 transition-colors"
+                                    onClick={() => setShowCurrentPassword(v => !v)}
+                                    title={showCurrentPassword ? "Ocultar senha" : "Mostrar senha"}
+                                    tabIndex={-1}
+                                >
+                                    {showCurrentPassword ? (
+                                        <EyeOff className="w-4 h-4" />
+                                    ) : (
+                                        <Eye className="w-4 h-4" />
+                                    )}
+                                </button>
+                            </div>
+                            {currentPasswordError && (
+                                <p className="text-sm text-red-600 mt-1.5">{currentPasswordError}</p>
+                            )}
+                        </div>
+
+                        {/* Nova Senha */}
+                        <div>
+                            <Label htmlFor="newPassword" className="mb-1.5 text-stone-700">
+                                Nova Senha
+                            </Label>
+                            <div className="relative">
+                                <Input
+                                    type={showNewPassword ? "text" : "password"}
+                                    id="newPassword"
+                                    className={`pr-10 ${
+                                        newPasswordError ? "border-red-400 ring-2 ring-red-100" : ""
+                                    }`}
+                                    aria-invalid={newPasswordError ? true : undefined}
+                                    required
+                                    value={newPassword}
+                                    onChange={e => setNewPassword(e.target.value)}
+                                    onBlur={e => setNewPasswordError(validateNewPassword(e.target.value))}
+                                />
+                                <button
+                                    type="button"
+                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 transition-colors"
+                                    onClick={() => setShowNewPassword(v => !v)}
+                                    title={showNewPassword ? "Ocultar senha" : "Mostrar senha"}
+                                    tabIndex={-1}
+                                >
+                                    {showNewPassword ? (
+                                        <EyeOff className="w-4 h-4" />
+                                    ) : (
+                                        <Eye className="w-4 h-4" />
+                                    )}
+                                </button>
+                            </div>
+                            {newPasswordError && (
+                                <p className="text-sm text-red-600 mt-1.5">{newPasswordError}</p>
+                            )}
+                        </div>
+
+                        {/* Confirmar Nova Senha */}
+                        <div>
+                            <Label htmlFor="confirmPassword" className="mb-1.5 text-stone-700">
+                                Confirmar Nova Senha
+                            </Label>
+                            <div className="relative">
+                                <Input
+                                    type={showConfirmPassword ? "text" : "password"}
+                                    id="confirmPassword"
+                                    className={`pr-10 ${
+                                        confirmPasswordError ? "border-red-400 ring-2 ring-red-100" : ""
+                                    }`}
+                                    aria-invalid={confirmPasswordError ? true : undefined}
+                                    required
+                                    value={confirmPassword}
+                                    onChange={e => setConfirmPassword(e.target.value)}
+                                    onBlur={e => setConfirmPasswordError(validateConfirmPassword(e.target.value, newPassword))}
+                                />
+                                <button
+                                    type="button"
+                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 transition-colors"
+                                    onClick={() => setShowConfirmPassword(v => !v)}
+                                    title={showConfirmPassword ? "Ocultar senha" : "Mostrar senha"}
+                                    tabIndex={-1}
+                                >
+                                    {showConfirmPassword ? (
+                                        <EyeOff className="w-4 h-4" />
+                                    ) : (
+                                        <Eye className="w-4 h-4" />
+                                    )}
+                                </button>
+                            </div>
+                            {confirmPasswordError && (
+                                <p className="text-sm text-red-600 mt-1.5">{confirmPasswordError}</p>
+                            )}
+                        </div>
+
+                        <Button
+                            type="submit"
+                            disabled={submitting}
+                            className="w-full"
+                            size="lg"
+                        >
+                            {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+                            {submitting ? "Alterando..." : "Alterar Senha"}
+                        </Button>
+                    </form>
+                </div>
+            </div>
         </div>
     );
 }

--- a/front/src/pages/classDetails/ActivitiesTab.tsx
+++ b/front/src/pages/classDetails/ActivitiesTab.tsx
@@ -28,12 +28,12 @@ interface ActivitiesTabProps {
 }
 
 const stripColours = [
-  "linear-gradient(90deg, #14b8a6, #34d399)",
-  "linear-gradient(90deg, #f59e0b, #fb923c)",
-  "linear-gradient(90deg, #38bdf8, #22d3ee)",
-  "linear-gradient(90deg, #fb7185, #f472b6)",
-  "linear-gradient(90deg, #a78bfa, #c084fc)",
-  "linear-gradient(90deg, #a3e635, #4ade80)",
+  "bg-gradient-to-r from-teal-500 to-emerald-400",
+  "bg-gradient-to-r from-amber-500 to-orange-400",
+  "bg-gradient-to-r from-sky-400 to-cyan-400",
+  "bg-gradient-to-r from-rose-400 to-pink-400",
+  "bg-gradient-to-r from-violet-400 to-purple-400",
+  "bg-gradient-to-r from-lime-400 to-emerald-400",
 ];
 
 const statusConfig = {
@@ -60,7 +60,7 @@ export default function ActivitiesTab({
   const isProfessor = hasAnyRole(["professor", "admin"]);
 
   return (
-    <div className="bg-white p-6 rounded-2xl border border-stone-200 shadow-sm">
+    <div className="bg-white p-4 sm:p-6 rounded-2xl border border-stone-200 shadow-sm">
       <style>{`
         @keyframes activities-fade-up {
           from { opacity: 0; transform: translateY(18px); }
@@ -68,12 +68,11 @@ export default function ActivitiesTab({
         }
       `}</style>
 
-      <div className="flex justify-between items-center mb-5">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-0 mb-5">
         <h2 className="text-lg font-semibold text-stone-800">Atividades da Turma</h2>
         {isProfessor && (
           <Button onClick={onNewActivity}
-            className="text-white rounded-xl hover:opacity-90 font-semibold transition-opacity h-11 px-6"
-            style={{ backgroundColor: "#0d9488" }}>
+            className="text-white rounded-xl hover:opacity-90 font-semibold transition-opacity h-11 px-6 bg-teal-600 hover:bg-teal-700">
             <Plus className="w-4 h-4 mr-2" />
             Nova Atividade
           </Button>
@@ -83,8 +82,8 @@ export default function ActivitiesTab({
       <div className="space-y-3">
         {activities.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16">
-            <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4" style={{ backgroundColor: "#ccfbf1" }}>
-              <BookOpen className="w-7 h-7" style={{ color: "#0d9488" }} />
+            <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4 bg-teal-100">
+              <BookOpen className="w-7 h-7 text-teal-600" />
             </div>
             <p className="text-sm font-medium text-stone-600">Nenhuma atividade cadastrada</p>
             <p className="text-xs text-stone-400 mt-1">Crie a primeira atividade para esta turma</p>
@@ -100,12 +99,12 @@ export default function ActivitiesTab({
             return (
               <div
                 key={activity.id}
-                className="group bg-white rounded-2xl border border-stone-200 shadow-sm hover:shadow-md transition-shadow duration-300 overflow-hidden"
-                style={{ animation: "activities-fade-up 0.5s cubic-bezier(.22,1,.36,1) both", animationDelay: `${index * 60}ms` }}
+                className="group bg-white rounded-2xl border border-stone-200 shadow-sm hover:shadow-md transition-shadow duration-300 overflow-hidden animate-[activities-fade-up_0.5s_cubic-bezier(.22,1,.36,1)_both]"
+                style={{ animationDelay: `${index * 60}ms` }}
               >
-                <div className="h-1.5" style={{ background: stripColours[index % stripColours.length] }} />
+                <div className={`h-1.5 ${stripColours[index % stripColours.length]}`} />
 
-                <div className="px-5 py-3.5 flex items-center gap-4">
+                <div className="px-4 py-3 sm:px-5 sm:py-3.5 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
                   {/* Left: info */}
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2.5">
@@ -148,7 +147,7 @@ export default function ActivitiesTab({
                   </div>
 
                   {/* Right: actions */}
-                  <div className="flex items-center gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex items-center gap-1 flex-shrink-0 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
                     <button onClick={(e) => { e.stopPropagation(); onViewActivity(activity); }}
                       className="rounded-lg p-1.5 text-stone-400 hover:text-teal-600 hover:bg-teal-50 transition-colors" title="Ver Problema">
                       <Eye className="w-4 h-4" />

--- a/front/src/pages/classDetails/ClassDetails.tsx
+++ b/front/src/pages/classDetails/ClassDetails.tsx
@@ -74,7 +74,7 @@ export default function ClassDetails() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-6 py-10 space-y-8">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-10 space-y-8">
       {notification && (
         <Notification
           message={notification.message}
@@ -85,8 +85,7 @@ export default function ClassDetails() {
 
       <button
         onClick={() => navigate("/classes")}
-        className="inline-flex items-center gap-1 text-sm font-medium transition-colors"
-        style={{ color: "#0d9488" }}
+        className="inline-flex items-center gap-1 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
       >
         <ArrowLeft className="w-4 h-4" />
         Voltar para Turmas
@@ -101,7 +100,7 @@ export default function ClassDetails() {
       {activeJam && <JamSessionBanner session={activeJam} />}
 
       <Tabs defaultValue={defaultTab} className="w-full">
-        <TabsList className="grid w-full grid-cols-3 mb-6">
+        <TabsList className="grid w-full grid-cols-1 sm:grid-cols-3 mb-6">
           <TabsTrigger value="activities" className="flex items-center gap-2">
             <BookOpen className="w-4 h-4" />
             Atividades ({activities.length})

--- a/front/src/pages/classDetails/ClassHero.tsx
+++ b/front/src/pages/classDetails/ClassHero.tsx
@@ -10,16 +10,15 @@ interface ClassHeroProps {
 export default function ClassHero({ classData, activityCount, studentCount }: ClassHeroProps) {
   return (
     <div
-      className="relative rounded-2xl px-8 py-10 overflow-hidden"
-      style={{ background: "linear-gradient(135deg, #0d9488 0%, #065f46 100%)" }}
+      className="relative rounded-2xl px-6 py-8 sm:px-8 sm:py-10 overflow-hidden bg-gradient-to-br from-teal-600 to-emerald-800"
     >
       <div className="absolute -top-6 -right-6 h-32 w-32 rounded-full bg-white opacity-10" />
       <div className="absolute bottom-4 left-1/3 h-20 w-20 rounded-full bg-white opacity-[0.07]" />
 
       <div className="relative flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-extrabold tracking-tight text-white flex items-center gap-3">
-            <BookOpen className="w-8 h-8" />
+          <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight text-white flex items-center gap-3">
+            <BookOpen className="w-7 h-7 sm:w-8 sm:h-8" />
             {classData.nome}
           </h1>
           {classData.teacherName && (

--- a/front/src/pages/classDetails/JamSessionsTab.tsx
+++ b/front/src/pages/classDetails/JamSessionsTab.tsx
@@ -14,8 +14,8 @@ export default function JamSessionsTab({ jamSessions, classId }: JamSessionsTabP
   const { hasAnyRole } = useUserRole();
 
   return (
-    <div className="bg-white p-6 rounded-2xl border border-stone-200 shadow-sm">
-      <div className="flex justify-between items-center mb-4">
+    <div className="bg-white p-4 sm:p-6 rounded-2xl border border-stone-200 shadow-sm">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-0 mb-4">
         <h2 className="text-lg font-semibold text-stone-800">Jam Sessions</h2>
         {hasAnyRole(["professor", "admin"]) && (
           <Button
@@ -30,8 +30,8 @@ export default function JamSessionsTab({ jamSessions, classId }: JamSessionsTabP
 
       {jamSessions.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16">
-          <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4" style={{ backgroundColor: "#ccfbf1" }}>
-            <Codesandbox className="w-7 h-7" style={{ color: "#0d9488" }} />
+          <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4 bg-teal-100">
+            <Codesandbox className="w-7 h-7 text-teal-600" />
           </div>
           <p className="text-sm font-medium text-stone-600">Nenhuma jam session criada</p>
           <p className="text-xs text-stone-400 mt-1">Crie uma sessão para começar</p>
@@ -42,25 +42,25 @@ export default function JamSessionsTab({ jamSessions, classId }: JamSessionsTabP
             <div
               key={jam.id}
               onClick={() => navigate(`/jam/${jam.id}`)}
-              className="flex items-center justify-between rounded-lg border border-stone-200 p-4 cursor-pointer hover:bg-stone-50 transition-colors"
+              className="flex flex-col sm:flex-row sm:items-center justify-between rounded-lg border border-stone-200 p-4 cursor-pointer hover:bg-stone-50 transition-colors gap-3"
             >
-              <div>
-                <h3 className="font-semibold text-stone-800">{jam.titulo}</h3>
-                <p className="text-sm text-stone-500">
+              <div className="min-w-0">
+                <h3 className="font-semibold text-stone-800 truncate">{jam.titulo}</h3>
+                <p className="text-sm text-stone-500 truncate">
                   Problema: {jam.problema?.titulo || "—"}
                   {jam.tempo_limite && ` · ${jam.tempo_limite} min`}
                 </p>
               </div>
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-3 flex-shrink-0">
                 <span className="text-xs text-stone-400">
                   {jam.participants?.length || 0} participantes
                 </span>
                 <span
                   className={`rounded-full px-3 py-1 text-xs font-medium ${
                     jam.status === "active"
-                      ? "bg-green-100 text-green-700"
+                      ? "bg-emerald-50 text-emerald-700"
                       : jam.status === "waiting"
-                      ? "bg-yellow-100 text-yellow-700"
+                      ? "bg-amber-50 text-amber-700"
                       : "bg-stone-100 text-stone-600"
                   }`}
                 >

--- a/front/src/pages/classDetails/StudentsTab.tsx
+++ b/front/src/pages/classDetails/StudentsTab.tsx
@@ -29,8 +29,8 @@ export default function StudentsTab({
   const { hasAnyRole } = useUserRole();
 
   return (
-    <div className="bg-white p-6 rounded-2xl border border-stone-200 shadow-sm">
-      <div className="flex justify-between items-center mb-4">
+    <div className="bg-white p-4 sm:p-6 rounded-2xl border border-stone-200 shadow-sm">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-0 mb-4">
         <h2 className="text-lg font-semibold text-stone-800">Alunos Matriculados</h2>
         {hasAnyRole(["professor", "admin"]) && (
           <Button onClick={onToggleAddStudent}>
@@ -90,8 +90,8 @@ export default function StudentsTab({
       <div className="space-y-2">
         {students.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16">
-            <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4" style={{ backgroundColor: "#ccfbf1" }}>
-              <Users className="w-7 h-7" style={{ color: "#0d9488" }} />
+            <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4 bg-teal-100">
+              <Users className="w-7 h-7 text-teal-600" />
             </div>
             <p className="text-sm font-medium text-stone-600">Nenhum aluno matriculado</p>
             <p className="text-xs text-stone-400 mt-1">Adicione alunos a esta turma</p>

--- a/front/src/pages/classes/ClassCard.tsx
+++ b/front/src/pages/classes/ClassCard.tsx
@@ -1,0 +1,106 @@
+import { useNavigate } from "react-router";
+import type { Class } from "@/types/classes";
+import { Button } from "@/components/ui/button";
+import {
+  Edit,
+  Trash2,
+  Users,
+  UserPlus,
+  ChevronRight,
+} from "lucide-react";
+
+interface ClassCardProps {
+  cls: Class;
+  index: number;
+  isProfOrAdmin: boolean;
+  onEdit: (cls: Class) => void;
+  onDelete: (id: number) => void;
+}
+
+export function ClassCard({
+  cls,
+  index,
+  isProfOrAdmin,
+  onEdit,
+  onDelete,
+}: ClassCardProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className="cls-card group relative flex flex-col rounded-xl border border-stone-200 bg-white shadow-sm hover:shadow-md transition-shadow duration-300"
+      style={{ animationDelay: `${index * 60}ms` }}
+    >
+      <div className="flex flex-col flex-1 px-3 py-3 sm:px-5 sm:py-5">
+        {/* header row */}
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <h3 className="text-sm sm:text-base font-bold leading-snug text-stone-800 line-clamp-2">
+            {cls.nome}
+          </h3>
+
+          {isProfOrAdmin && (
+            <div className="flex gap-1 shrink-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+              <button
+                onClick={() => onEdit(cls)}
+                className="rounded-lg p-1.5 text-stone-400 hover:text-teal-600 hover:bg-teal-50 transition-colors"
+                title="Editar"
+              >
+                <Edit className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => onDelete(cls.id)}
+                className="rounded-lg p-1.5 text-stone-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+                title="Excluir"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* meta */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-stone-500 mb-5">
+          {cls.teacherName && (
+            <span className="flex items-center gap-1.5">
+              <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-teal-600 text-[10px] font-bold text-white">
+                {cls.teacherName.charAt(0).toUpperCase()}
+              </span>
+              {cls.teacherName}
+            </span>
+          )}
+          <span className="flex items-center gap-1.5">
+            <Users className="w-3.5 h-3.5" />
+            {cls.studentsCount || 0} aluno{(cls.studentsCount ?? 0) !== 1 && "s"}
+          </span>
+        </div>
+
+        {/* spacer */}
+        <div className="flex-1" />
+
+        {/* actions */}
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            onClick={() => navigate(`/classes/${cls.id}`)}
+            className="flex-1 flex items-center justify-center gap-2 rounded-xl h-10 text-sm font-semibold bg-teal-50 text-teal-600 hover:bg-teal-600 hover:text-white transition-colors"
+          >
+            Ver Detalhes
+            <ChevronRight className="w-4 h-4" />
+          </Button>
+
+          {isProfOrAdmin && (
+            <Button
+              variant="outline"
+              aria-label="Gerenciar alunos"
+              onClick={() => navigate(`/classes/${cls.id}?tab=students`)}
+              className="flex items-center justify-center gap-2 rounded-xl h-10 px-4 text-sm font-semibold border-stone-300 text-stone-500 hover:border-teal-600 hover:text-teal-600 hover:bg-teal-50 transition-colors"
+            >
+              <UserPlus className="w-4 h-4" />
+              <span className="hidden sm:inline">Alunos</span>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/classes/ClassFormInline.tsx
+++ b/front/src/pages/classes/ClassFormInline.tsx
@@ -1,0 +1,60 @@
+import type { CreateClassDTO } from "@/types/classes";
+import type { Class } from "@/types/classes";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface ClassFormInlineProps {
+  formData: CreateClassDTO;
+  editingClass: Class | null;
+  onFormDataChange: (data: CreateClassDTO) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onCancel: () => void;
+}
+
+export function ClassFormInline({
+  formData,
+  editingClass,
+  onFormDataChange,
+  onSubmit,
+  onCancel,
+}: ClassFormInlineProps) {
+  return (
+    <div className="cls-form-enter rounded-xl border border-stone-200 bg-white px-3 py-3 sm:px-5 sm:py-5 shadow-sm mb-6">
+      <h2 className="text-base sm:text-lg font-bold text-stone-800 mb-4">
+        {editingClass ? "Editar Turma" : "Criar Nova Turma"}
+      </h2>
+      <form onSubmit={onSubmit} className="flex flex-col sm:flex-row items-end gap-4">
+        <div className="flex-1 w-full">
+          <Label htmlFor="nome" className="mb-1.5 block text-sm font-medium text-stone-600">
+            Nome da turma
+          </Label>
+          <Input
+            id="nome"
+            value={formData.nome}
+            onChange={(e) => onFormDataChange({ ...formData, nome: e.target.value })}
+            required
+            placeholder="Ex: Programação I — 2025/1"
+            className="h-11 rounded-lg"
+          />
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <Button
+            type="submit"
+            className="h-11 rounded-xl px-6 font-semibold bg-teal-600 text-white hover:bg-teal-700"
+          >
+            {editingClass ? "Atualizar" : "Salvar"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onCancel}
+            className="h-11 rounded-xl text-stone-500 hover:text-red-600 hover:bg-red-50"
+          >
+            Cancelar
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/front/src/pages/classes/Classes.tsx
+++ b/front/src/pages/classes/Classes.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useRef } from "react";
-import { useNavigate } from "react-router";
 import type { Class, CreateClassDTO } from "@/types/classes";
 import ClassesService from "@/services/ClassesService";
 import { Button } from "@/components/ui/button";
@@ -20,7 +19,6 @@ import { ClassFormInline } from "./ClassFormInline";
 
 /* ================================================================== */
 export default function Classes() {
-  const navigate = useNavigate();
   const { hasAnyRole } = useUserRole();
   const { user } = useUser();
 

--- a/front/src/pages/classes/Classes.tsx
+++ b/front/src/pages/classes/Classes.tsx
@@ -3,54 +3,20 @@ import { useNavigate } from "react-router";
 import type { Class, CreateClassDTO } from "@/types/classes";
 import ClassesService from "@/services/ClassesService";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import Loading from "@/components/Loading";
 import Notification from "@/components/Notification";
 import {
   Plus,
-  Edit,
-  Trash2,
-  Users,
-  UserPlus,
   BookOpen,
   X,
-  ChevronRight,
   Sparkles,
 } from "lucide-react";
 import { SearchFilter } from "@/components/SearchFilter";
 import { HeroHeader } from "@/components/HeroHeader";
 import { useUserRole } from "@/hooks/useUserRole";
 import { useUser } from "@/context/UserContext";
-
-/* ── palette tokens (inline, no global leak) ────────────────── */
-const palette = {
-  accent: "#0d9488",        // teal-600
-  accentLight: "#ccfbf1",   // teal-100
-  accentSoft: "#f0fdfa",    // teal-50
-  warm: "#f59e0b",          // amber-500
-  warmLight: "#fef3c7",     // amber-100
-  surface: "#fafaf9",       // stone-50
-  cardBg: "#ffffff",
-  textPrimary: "#1c1917",   // stone-900
-  textSecondary: "#78716c", // stone-500
-  border: "#e7e5e4",        // stone-300
-  dangerText: "#dc2626",
-  dangerBg: "#fef2f2",
-};
-
-/* ── colour helpers for card accent strips ───────────────── */
-const stripColours = [
-  "from-teal-500 to-emerald-400",
-  "from-amber-400 to-orange-400",
-  "from-sky-400 to-cyan-400",
-  "from-rose-400 to-pink-400",
-  "from-violet-400 to-purple-400",
-  "from-lime-400 to-green-400",
-];
-function stripFor(index: number) {
-  return stripColours[index % stripColours.length];
-}
+import { ClassCard } from "./ClassCard";
+import { ClassFormInline } from "./ClassFormInline";
 
 /* ================================================================== */
 export default function Classes() {
@@ -204,7 +170,7 @@ export default function Classes() {
         />
       )}
 
-      {/* ═══════ HERO / HEADER AREA ═══════ */}
+      {/* ======= HERO / HEADER AREA ======= */}
       <HeroHeader
         icon={BookOpen}
         title="Minhas Turmas"
@@ -213,7 +179,7 @@ export default function Classes() {
           : "Veja as turmas em que você está matriculado e acesse as atividades."}
       />
 
-      {/* ═══════ SEARCH BAR + NEW CLASS BUTTON ═══════ */}
+      {/* ======= SEARCH BAR + NEW CLASS BUTTON ======= */}
       <div className="flex items-center gap-3 mb-6">
         <div className="flex-1">
           <SearchFilter
@@ -242,60 +208,27 @@ export default function Classes() {
 
       {/* ── inline form ── */}
       {showForm && (
-        <div className="cls-form-enter rounded-xl border border-stone-200 bg-white p-6 shadow-sm mb-6">
-          <h2 className="text-lg font-bold text-stone-800 mb-4">
-            {editingClass ? "Editar Turma" : "Criar Nova Turma"}
-          </h2>
-          <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row items-end gap-4">
-            <div className="flex-1 w-full">
-              <Label htmlFor="nome" className="mb-1.5 block text-sm font-medium text-stone-600">
-                Nome da turma
-              </Label>
-              <Input
-                id="nome"
-                value={formData.nome}
-                onChange={(e) => setFormData({ ...formData, nome: e.target.value })}
-                required
-                placeholder="Ex: Programação I — 2025/1"
-                className="h-11 rounded-lg"
-              />
-            </div>
-            <div className="flex gap-2 shrink-0">
-              <Button
-                type="submit"
-                className="h-11 rounded-xl px-6 font-semibold"
-                style={{ background: palette.accent }}
-              >
-                {editingClass ? "Atualizar" : "Salvar"}
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={resetForm}
-                className="h-11 rounded-xl text-stone-500 hover:text-red-600 hover:bg-red-50"
-              >
-                Cancelar
-              </Button>
-            </div>
-          </form>
-        </div>
+        <ClassFormInline
+          formData={formData}
+          editingClass={editingClass}
+          onFormDataChange={setFormData}
+          onSubmit={handleSubmit}
+          onCancel={resetForm}
+        />
       )}
 
-      {/* ═══════ CARDS GRID ═══════ */}
+      {/* ======= CARDS GRID ======= */}
       <div
         ref={gridRef}
-        className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5"
+        className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-4"
       >
         {filteredClasses.length === 0 ? (
           /* ── empty state ── */
           <div className="col-span-full flex flex-col items-center justify-center py-24 text-center">
-            <div
-              className="mb-5 flex h-20 w-20 items-center justify-center rounded-2xl"
-              style={{ background: palette.accentLight }}
-            >
-              <Sparkles className="w-9 h-9" style={{ color: palette.accent }} />
+            <div className="mb-5 flex h-20 w-20 items-center justify-center rounded-2xl bg-teal-100">
+              <Sparkles className="w-9 h-9 text-teal-600" />
             </div>
-            <p className="text-lg font-semibold text-stone-700">
+            <p className="text-base sm:text-lg font-semibold text-stone-700">
               {searchTerm ? "Nenhuma turma encontrada" : "Nenhuma turma por aqui"}
             </p>
             <p className="mt-1 text-sm text-stone-400 max-w-xs">
@@ -308,117 +241,14 @@ export default function Classes() {
           </div>
         ) : (
           filteredClasses.map((cls, i) => (
-            <div
+            <ClassCard
               key={cls.id}
-              className="cls-card group relative flex flex-col rounded-2xl border bg-white shadow-sm hover:shadow-md transition-shadow duration-300"
-              style={{
-                animationDelay: `${i * 60}ms`,
-                borderColor: palette.border,
-              }}
-            >
-              {/* colour accent strip */}
-              <div
-                className={`h-1.5 rounded-t-2xl bg-gradient-to-r ${stripFor(i)}`}
-              />
-
-              <div className="flex flex-col flex-1 p-5 pt-4">
-                {/* header row */}
-                <div className="flex items-start justify-between gap-3 mb-3">
-                  <h3 className="text-[1.05rem] font-bold leading-snug text-stone-800 line-clamp-2">
-                    {cls.nome}
-                  </h3>
-
-                  {isProfOrAdmin && (
-                    <div className="flex gap-1 shrink-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-                      <button
-                        onClick={() => handleEdit(cls)}
-                        className="rounded-lg p-1.5 text-stone-400 hover:text-teal-600 hover:bg-teal-50 transition-colors"
-                        title="Editar"
-                      >
-                        <Edit className="w-4 h-4" />
-                      </button>
-                      <button
-                        onClick={() => handleDelete(cls.id)}
-                        className="rounded-lg p-1.5 text-stone-400 hover:text-red-600 hover:bg-red-50 transition-colors"
-                        title="Excluir"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                  )}
-                </div>
-
-                {/* meta */}
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-stone-500 mb-5">
-                  {cls.teacherName && (
-                    <span className="flex items-center gap-1.5">
-                      <span
-                        className="inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-bold text-white"
-                        style={{ background: palette.accent }}
-                      >
-                        {cls.teacherName.charAt(0).toUpperCase()}
-                      </span>
-                      {cls.teacherName}
-                    </span>
-                  )}
-                  <span className="flex items-center gap-1.5">
-                    <Users className="w-3.5 h-3.5" />
-                    {cls.studentsCount || 0} aluno{(cls.studentsCount ?? 0) !== 1 && "s"}
-                  </span>
-                </div>
-
-                {/* spacer */}
-                <div className="flex-1" />
-
-                {/* actions */}
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => navigate(`/classes/${cls.id}`)}
-                    className="flex-1 flex items-center justify-center gap-2 rounded-xl h-10 text-sm font-semibold transition-colors"
-                    style={{
-                      color: palette.accent,
-                      background: palette.accentSoft,
-                    }}
-                    onMouseEnter={(e) => {
-                      e.currentTarget.style.background = palette.accent;
-                      e.currentTarget.style.color = "#fff";
-                    }}
-                    onMouseLeave={(e) => {
-                      e.currentTarget.style.background = palette.accentSoft;
-                      e.currentTarget.style.color = palette.accent;
-                    }}
-                  >
-                    Ver Detalhes
-                    <ChevronRight className="w-4 h-4" />
-                  </button>
-
-                  {isProfOrAdmin && (
-                    <button
-                      aria-label="Gerenciar alunos"
-                      onClick={() => navigate(`/classes/${cls.id}?tab=students`)}
-                      className="flex items-center justify-center gap-2 rounded-xl h-10 px-4 text-sm font-semibold border transition-colors"
-                      style={{
-                        borderColor: palette.border,
-                        color: palette.textSecondary,
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.borderColor = palette.accent;
-                        e.currentTarget.style.color = palette.accent;
-                        e.currentTarget.style.background = palette.accentSoft;
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.borderColor = palette.border;
-                        e.currentTarget.style.color = palette.textSecondary;
-                        e.currentTarget.style.background = "transparent";
-                      }}
-                    >
-                      <UserPlus className="w-4 h-4" />
-                      <span className="hidden sm:inline">Alunos</span>
-                    </button>
-                  )}
-                </div>
-              </div>
-            </div>
+              cls={cls}
+              index={i}
+              isProfOrAdmin={isProfOrAdmin}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
           ))
         )}
       </div>

--- a/front/src/pages/forgotPassword/ForgotPassword.tsx
+++ b/front/src/pages/forgotPassword/ForgotPassword.tsx
@@ -4,6 +4,9 @@ import axios from "axios";
 import Notification from "@/components/Notification";
 import { sendForgotPasswordEmail } from "@/services/ForgotPasswordService";
 import { ArrowLeft, Terminal, Loader2, Mail } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 
 export default function ForgotPassword() {
   const [error, setError] = useState<string | null>(null);
@@ -70,17 +73,10 @@ export default function ForgotPassword() {
         />
       )}
 
-      <div className="w-full min-h-screen flex">
+      <div className="min-h-screen flex">
         {/* Left panel */}
-        <div className="hidden lg:flex lg:w-[45%] bg-zinc-900 relative overflow-hidden flex-col justify-between p-12">
-          <div
-            className="absolute inset-0 opacity-[0.04]"
-            style={{
-              backgroundImage:
-                "linear-gradient(rgba(255,255,255,.1) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.1) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-            }}
-          />
+        <div className="hidden lg:flex lg:w-[45%] bg-stone-900 relative overflow-hidden flex-col justify-between p-12">
+          <div className="absolute inset-0 opacity-[0.04] bg-[linear-gradient(rgba(255,255,255,.1)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.1)_1px,transparent_1px)] bg-[size:40px_40px]" />
 
           <div className="relative z-10">
             <div className="flex items-center gap-3 mb-8">
@@ -99,7 +95,7 @@ export default function ForgotPassword() {
               <br />
               acesso.
             </h2>
-            <p className="text-zinc-400 text-sm mt-4 max-w-xs leading-relaxed">
+            <p className="text-stone-400 text-sm mt-4 max-w-xs leading-relaxed">
               Enviaremos um link para o seu e-mail com instruções para redefinir
               sua senha.
             </p>
@@ -111,10 +107,10 @@ export default function ForgotPassword() {
           <div className="w-full max-w-sm">
             {/* Mobile logo */}
             <div className="flex items-center gap-2.5 mb-10 lg:hidden">
-              <div className="w-8 h-8 rounded-md bg-zinc-900 flex items-center justify-center">
+              <div className="w-8 h-8 rounded-md bg-stone-900 flex items-center justify-center">
                 <Terminal className="w-4 h-4 text-white" />
               </div>
-              <span className="text-zinc-900 text-lg font-bold tracking-tight">
+              <span className="text-stone-900 text-lg font-bold tracking-tight">
                 IFCodes
               </span>
             </div>
@@ -123,7 +119,7 @@ export default function ForgotPassword() {
             <button
               type="button"
               onClick={() => navigate("/login")}
-              className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-zinc-700 transition-colors mb-8"
+              className="flex items-center gap-1.5 text-sm text-stone-400 hover:text-stone-700 transition-colors mb-8"
             >
               <ArrowLeft className="w-4 h-4" />
               Voltar para Login
@@ -135,10 +131,10 @@ export default function ForgotPassword() {
                 <div className="w-12 h-12 rounded-xl bg-teal-50 flex items-center justify-center mx-auto mb-5">
                   <Mail className="w-6 h-6 text-teal-600" />
                 </div>
-                <h1 className="text-xl font-bold text-zinc-900 tracking-tight">
+                <h1 className="text-xl font-bold text-stone-900 tracking-tight">
                   E-mail enviado
                 </h1>
-                <p className="text-sm text-zinc-400 mt-2 leading-relaxed max-w-xs mx-auto">
+                <p className="text-sm text-stone-400 mt-2 leading-relaxed max-w-xs mx-auto">
                   Se o e-mail estiver cadastrado, você receberá um link para
                   redefinir sua senha. Verifique também a caixa de spam.
                 </p>
@@ -157,10 +153,10 @@ export default function ForgotPassword() {
               /* Form state */
               <>
                 <div className="mb-8">
-                  <h1 className="text-xl font-bold text-zinc-900 tracking-tight">
+                  <h1 className="text-xl font-bold text-stone-900 tracking-tight">
                     Recuperar senha
                   </h1>
-                  <p className="text-sm text-zinc-400 mt-1.5">
+                  <p className="text-sm text-stone-400 mt-1.5">
                     Digite seu e-mail e enviaremos um link para redefinir sua
                     senha.
                   </p>
@@ -168,21 +164,19 @@ export default function ForgotPassword() {
 
                 <form onSubmit={handleSubmit} className="space-y-5">
                   <div>
-                    <label
-                      htmlFor="email"
-                      className="block text-sm font-medium text-zinc-700 mb-1.5"
-                    >
+                    <Label htmlFor="email" className="mb-1.5 text-stone-700">
                       Email
-                    </label>
-                    <input
+                    </Label>
+                    <Input
                       type="email"
                       id="email"
                       placeholder="seu@email.com"
-                      className={`w-full px-3 py-2.5 text-sm bg-white border rounded-lg outline-none transition-all ${
+                      className={
                         emailError
                           ? "border-red-400 ring-2 ring-red-100"
-                          : "border-zinc-200 focus:border-teal-500 focus:ring-2 focus:ring-teal-100"
-                      }`}
+                          : ""
+                      }
+                      aria-invalid={emailError ? true : undefined}
                       required
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
@@ -191,16 +185,17 @@ export default function ForgotPassword() {
                       }
                     />
                     {emailError && (
-                      <p className="text-red-600 text-xs mt-1.5">
+                      <p className="text-sm text-red-600 mt-1.5">
                         {emailError}
                       </p>
                     )}
                   </div>
 
-                  <button
+                  <Button
                     type="submit"
                     disabled={loading}
-                    className="w-full bg-teal-600 hover:bg-teal-700 disabled:opacity-60 disabled:cursor-not-allowed text-white text-sm font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2"
+                    className="w-full"
+                    size="lg"
                   >
                     {loading ? (
                       <>
@@ -210,7 +205,7 @@ export default function ForgotPassword() {
                     ) : (
                       "Enviar link de recuperação"
                     )}
-                  </button>
+                  </Button>
                 </form>
               </>
             )}

--- a/front/src/pages/home/Home.tsx
+++ b/front/src/pages/home/Home.tsx
@@ -264,7 +264,7 @@ export default function Home() {
       <div className="home-section home-delay-3 grid grid-cols-1 lg:grid-cols-2 gap-4">
         <WeeklyHeatmap cells={heatmapCells} streak={streak} />
         <SectionCard title="Linguagens" icon={Terminal}>
-          <div className="px-5 py-5">
+          <div className="px-3 py-3 sm:px-5 sm:py-5">
             <LanguageBar stats={languageStats} />
           </div>
         </SectionCard>

--- a/front/src/pages/home/components/CircularProgress.tsx
+++ b/front/src/pages/home/components/CircularProgress.tsx
@@ -32,7 +32,7 @@ export function CircularProgress({ percentage, label }: CircularProgressProps) {
           cy={center}
           r={radius}
           fill="none"
-          stroke="#e7e5e4"
+          className="stroke-stone-200"
           strokeWidth={strokeWidth}
         />
         <circle
@@ -40,12 +40,10 @@ export function CircularProgress({ percentage, label }: CircularProgressProps) {
           cy={center}
           r={radius}
           fill="none"
-          stroke="#0d9488"
-          strokeWidth={strokeWidth}
+          className="stroke-teal-600 circular-progress-ring"
           strokeLinecap="round"
           strokeDasharray={circumference}
           strokeDashoffset={offset}
-          className="circular-progress-ring"
         />
       </svg>
     </div>

--- a/front/src/pages/home/components/ContinueCard.tsx
+++ b/front/src/pages/home/components/ContinueCard.tsx
@@ -41,7 +41,7 @@ export function ContinueCard({ activity, problemTitle }: ContinueCardProps) {
       <Button
         size="sm"
         onClick={() => navigate(`/activities/${activity.id}`)}
-        className={`hidden sm:flex min-h-[44px] rounded-xl shadow-none font-semibold shrink-0 ${
+        className={`hidden sm:flex min-h-11 rounded-xl shadow-none font-semibold shrink-0 ${
           isOverdue
             ? "bg-red-600 hover:bg-red-700 text-white"
             : "bg-amber-500 hover:bg-amber-600 text-white"

--- a/front/src/pages/home/components/SubmissionFeed.tsx
+++ b/front/src/pages/home/components/SubmissionFeed.tsx
@@ -30,7 +30,7 @@ export function SubmissionFeed({ submissions }: SubmissionFeedProps) {
         return (
           <div
             key={sub.id}
-            className="flex items-center gap-3 px-5 py-3 feed-row"
+            className="flex items-center gap-3 px-3 py-2.5 sm:px-5 sm:py-3 feed-row"
             style={{ animationDelay: `${i * 40}ms` }}
           >
             <span

--- a/front/src/pages/home/components/WeeklyHeatmap.tsx
+++ b/front/src/pages/home/components/WeeklyHeatmap.tsx
@@ -41,7 +41,7 @@ export function WeeklyHeatmap({ cells, streak }: WeeklyHeatmapProps) {
   ];
 
   return (
-    <div className="rounded-xl border border-stone-200 bg-white px-5 py-4">
+    <div className="rounded-xl border border-stone-200 bg-white px-3 py-3 sm:px-5 sm:py-4">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-xs font-semibold text-stone-500 uppercase tracking-wide">Atividade Semanal</h3>
         {streak > 0 && (

--- a/front/src/pages/jam/JamCreate.tsx
+++ b/front/src/pages/jam/JamCreate.tsx
@@ -70,10 +70,9 @@ export default function JamCreate() {
 
       {/* Hero Header */}
       <div
-        className="relative overflow-hidden px-4 sm:px-6 py-8 sm:py-12"
-        style={{ background: "linear-gradient(135deg, #0d9488 0%, #0f766e 100%)" }}
+        className="relative overflow-hidden bg-gradient-to-br from-teal-600 to-teal-700 px-4 sm:px-6 py-8 sm:py-12"
       >
-        <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-5xl">
           <button
             onClick={() => navigate(`/classes/${turmaId}`)}
             className="mb-6 flex items-center gap-2 text-sm font-medium text-white/80 transition-colors hover:text-white"
@@ -91,8 +90,8 @@ export default function JamCreate() {
       </div>
 
       {/* Form */}
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-6 sm:py-10 space-y-8">
-        <div className="rounded-2xl border border-stone-200 bg-white shadow-sm p-6">
+      <div className="mx-auto max-w-5xl px-4 sm:px-6 py-6 sm:py-10 space-y-8">
+        <div className="rounded-xl border border-stone-200 bg-white px-3 py-3 sm:px-5 sm:py-5 shadow-sm">
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
               <Label htmlFor="titulo">Título da Sessão</Label>
@@ -159,8 +158,7 @@ export default function JamCreate() {
               <Button
                 type="submit"
                 disabled={loading || !titulo || !problemaId}
-                style={{ backgroundColor: "#0d9488" }}
-                className="hover:opacity-90"
+                className="bg-teal-600 text-white hover:bg-teal-700"
               >
                 {loading ? "Criando..." : "Criar Sessão"}
               </Button>

--- a/front/src/pages/jam/JamLobby.tsx
+++ b/front/src/pages/jam/JamLobby.tsx
@@ -58,8 +58,7 @@ export default function JamLobby({ session, participants, isProfessor, onStart }
           <Button
             onClick={onStart}
             size="lg"
-            className="flex items-center gap-2 hover:opacity-90"
-            style={{ backgroundColor: "#0d9488" }}
+            className="flex items-center gap-2 bg-teal-600 text-white hover:bg-teal-700"
           >
             <Play className="h-5 w-5" />
             Iniciar Sessão

--- a/front/src/pages/jam/JamProfessorView.tsx
+++ b/front/src/pages/jam/JamProfessorView.tsx
@@ -257,8 +257,8 @@ export default function JamProfessorView({
 
       {/* Settings Modal */}
       {showSettings && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm">
-          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm px-4">
+          <div className="w-full max-w-md rounded-xl border border-stone-200 bg-white px-3 py-3 sm:px-5 sm:py-5 shadow-xl">
             <div className="mb-4 flex items-center justify-between">
               <h3 className="text-lg font-semibold text-stone-800">Configurações da Sessão</h3>
               <button onClick={() => setShowSettings(false)} className="rounded p-1 hover:bg-stone-100">
@@ -306,8 +306,7 @@ export default function JamProfessorView({
               </Button>
               <Button
                 onClick={handleSaveSettings}
-                style={{ backgroundColor: "#0d9488" }}
-                className="hover:opacity-90"
+                className="bg-teal-600 text-white hover:bg-teal-700"
               >
                 Salvar
               </Button>

--- a/front/src/pages/jam/JamResultsPanel.tsx
+++ b/front/src/pages/jam/JamResultsPanel.tsx
@@ -1,0 +1,167 @@
+import { CheckCircle2, XCircle, Loader2, MessageSquare, Terminal, FlaskConical, X } from "lucide-react";
+import type { JamSubmissionResult } from "@/hooks/useJamSession";
+
+interface ResultsPanelProps {
+  myStatus: string;
+  myResult: JamSubmissionResult | null;
+  compileError: string | null;
+  myFeedback: { message: string; created_at: string }[];
+  onClose?: () => void;
+  showClose?: boolean;
+}
+
+export default function JamResultsPanel({ myStatus, myResult, compileError, myFeedback, onClose, showClose }: ResultsPanelProps) {
+  return (
+    <div className="overflow-hidden">
+      <div className="px-3 py-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FlaskConical className="h-4 w-4 shrink-0 text-stone-400" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-stone-500 text-[0.7rem] tracking-[0.08em]">
+            Resultados
+          </span>
+        </div>
+        {showClose && onClose && (
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      <div className="mx-3 h-px bg-stone-200" />
+
+      <div className="p-3 space-y-3">
+        {myStatus === "passed" && (
+          <div className="space-y-2">
+            <div className="rounded-lg border border-green-200 bg-green-50 p-2.5">
+              <div className="flex items-center gap-2 text-green-700">
+                <CheckCircle2 className="h-4 w-4 shrink-0" />
+                <span className="text-xs font-semibold break-words">Todos os testes passaram!</span>
+              </div>
+            </div>
+            {myResult?.testResults && (
+              <div className="space-y-1.5">
+                {myResult.testResults.map((t, i) => (
+                  <div
+                    key={i}
+                    className="rounded-md border border-green-200 bg-green-50 p-2 text-xs font-medium text-green-700 overflow-hidden"
+                  >
+                    <div>Teste {i + 1}: {t.status}</div>
+                    {t.stdout && (
+                      <pre className="mt-1 whitespace-pre-wrap break-all font-mono text-green-600 leading-relaxed text-[11px]">
+                        {t.stdout}
+                      </pre>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {myStatus === "failed" && (
+          <div className="space-y-2">
+            <div className="rounded-lg border border-red-200 bg-red-50 p-2.5">
+              <div className="flex items-center gap-2 text-red-700">
+                <XCircle className="h-4 w-4 shrink-0" />
+                <span className="text-xs font-semibold break-words">
+                  {myResult?.statusMessage || "Alguns testes falharam"}
+                </span>
+              </div>
+            </div>
+            {compileError && (
+              <div className="rounded-lg border border-stone-200 bg-stone-50 p-2.5 overflow-hidden">
+                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-stone-500">
+                  <Terminal className="h-3 w-3 shrink-0" />
+                  Saida do compilador
+                </div>
+                <pre className="whitespace-pre-wrap break-all text-[11px] text-red-600 font-mono leading-relaxed">
+                  {compileError}
+                </pre>
+              </div>
+            )}
+            {myResult?.testResults && !compileError && (
+              <div className="space-y-1.5">
+                {myResult.testResults.map((t, i) => (
+                  <div
+                    key={i}
+                    className={`rounded-md border p-2 text-xs font-medium ${
+                      t.status === "Aceita"
+                        ? "border-green-200 bg-green-50 text-green-700"
+                        : "border-red-200 bg-red-50 text-red-700"
+                    }`}
+                  >
+                    Teste {i + 1}: {t.status}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {myStatus === "error" && (
+          <div className="space-y-2">
+            <div className="rounded-lg border border-red-200 bg-red-50 p-2.5">
+              <div className="flex items-center gap-2 text-red-700">
+                <XCircle className="h-4 w-4 shrink-0" />
+                <span className="text-xs font-semibold break-words">
+                  {myResult?.statusMessage || "Erro na execucao"}
+                </span>
+              </div>
+            </div>
+            {compileError && (
+              <div className="rounded-lg border border-stone-200 bg-stone-50 p-2.5 overflow-hidden">
+                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-stone-500">
+                  <Terminal className="h-3 w-3 shrink-0" />
+                  Detalhes do erro
+                </div>
+                <pre className="whitespace-pre-wrap break-all text-[11px] text-red-600 font-mono leading-relaxed">
+                  {compileError}
+                </pre>
+              </div>
+            )}
+          </div>
+        )}
+
+        {myStatus === "submitted" && (
+          <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-2.5">
+            <div className="flex items-center gap-2 text-yellow-700">
+              <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+              <span className="text-xs font-semibold">Avaliando...</span>
+            </div>
+          </div>
+        )}
+
+        {(myStatus === "joined" || myStatus === "coding") && (
+          <div className="rounded-lg border border-stone-200 bg-stone-50 p-2.5 text-xs text-stone-500">
+            Submeta seu codigo para ver os resultados.
+          </div>
+        )}
+
+        {/* Feedback Section */}
+        {myFeedback.length > 0 && (
+          <div>
+            <div className="mb-2 mt-1 h-px bg-stone-200" />
+            <div className="mb-2 flex items-center gap-2">
+              <MessageSquare className="h-3.5 w-3.5 shrink-0 text-stone-400" />
+              <span className="text-xs font-semibold uppercase tracking-wider text-stone-500 text-[0.7rem] tracking-[0.08em]">
+                Feedback ({myFeedback.length})
+              </span>
+            </div>
+            <div className="space-y-2">
+              {myFeedback.map((entry, i) => (
+                <div key={i} className="rounded-lg border border-stone-200 bg-stone-50 p-2.5">
+                  <p className="text-xs leading-relaxed text-stone-600 break-words">{entry.message}</p>
+                  <p className="mt-1 text-[10px] text-stone-400">
+                    {new Date(entry.created_at).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/jam/JamStudentView.tsx
+++ b/front/src/pages/jam/JamStudentView.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Send, CheckCircle2, XCircle, Loader2, MessageSquare, FileText, X, BookOpen, GraduationCap, Terminal, FlaskConical, BarChart3 } from "lucide-react";
+import { Send, CheckCircle2, XCircle, Loader2, FileText, X, BookOpen, GraduationCap, BarChart3 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Editor, { type OnMount } from "@monaco-editor/react";
 import { RichTextViewer } from "@/components/RichTextEditor";
 import JamTimer from "@/components/jam/JamTimer";
+import JamResultsPanel from "./JamResultsPanel";
 import type { JamSession, JamParticipant, JamStreamParticipant } from "@/types/jam";
 import type { JamSubmissionResult } from "@/hooks/useJamSession";
 
@@ -18,171 +19,6 @@ interface JamStudentViewProps {
 }
 
 const DEFAULT_CODE = "#include <stdio.h>\n\nint main() {\n    \n    return 0;\n}";
-
-interface ResultsPanelProps {
-  myStatus: string;
-  myResult: JamSubmissionResult | null;
-  compileError: string | null;
-  myFeedback: { message: string; created_at: string }[];
-  onClose?: () => void;
-  showClose?: boolean;
-}
-
-function ResultsPanel({ myStatus, myResult, compileError, myFeedback, onClose, showClose }: ResultsPanelProps) {
-  return (
-    <div className="overflow-hidden">
-      <div className="px-3 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <FlaskConical className="h-4 w-4 shrink-0 text-stone-400" />
-          <span className="text-xs font-semibold uppercase tracking-wider text-stone-500" style={{ fontSize: "0.7rem", letterSpacing: "0.08em" }}>
-            Resultados
-          </span>
-        </div>
-        {showClose && onClose && (
-          <button
-            onClick={onClose}
-            className="rounded-md p-1 text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        )}
-      </div>
-      <div className="mx-3 h-px bg-stone-200" />
-
-      <div className="p-3 space-y-3">
-        {myStatus === "passed" && (
-          <div className="space-y-2">
-            <div className="rounded-lg border border-green-200 bg-green-50 p-2.5">
-              <div className="flex items-center gap-2 text-green-700">
-                <CheckCircle2 className="h-4 w-4 shrink-0" />
-                <span className="text-xs font-semibold break-words">Todos os testes passaram!</span>
-              </div>
-            </div>
-            {myResult?.testResults && (
-              <div className="space-y-1.5">
-                {myResult.testResults.map((t, i) => (
-                  <div
-                    key={i}
-                    className="rounded-md border border-green-200 bg-green-50 p-2 text-xs font-medium text-green-700 overflow-hidden"
-                  >
-                    <div>Teste {i + 1}: {t.status}</div>
-                    {t.stdout && (
-                      <pre className="mt-1 whitespace-pre-wrap break-all font-mono text-green-600 leading-relaxed text-[11px]">
-                        {t.stdout}
-                      </pre>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {myStatus === "failed" && (
-          <div className="space-y-2">
-            <div className="rounded-lg border border-red-200 bg-red-50 p-2.5">
-              <div className="flex items-center gap-2 text-red-700">
-                <XCircle className="h-4 w-4 shrink-0" />
-                <span className="text-xs font-semibold break-words">
-                  {myResult?.statusMessage || "Alguns testes falharam"}
-                </span>
-              </div>
-            </div>
-            {compileError && (
-              <div className="rounded-lg border border-stone-200 bg-stone-50 p-2.5 overflow-hidden">
-                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-stone-500">
-                  <Terminal className="h-3 w-3 shrink-0" />
-                  Saída do compilador
-                </div>
-                <pre className="whitespace-pre-wrap break-all text-[11px] text-red-600 font-mono leading-relaxed">
-                  {compileError}
-                </pre>
-              </div>
-            )}
-            {myResult?.testResults && !compileError && (
-              <div className="space-y-1.5">
-                {myResult.testResults.map((t, i) => (
-                  <div
-                    key={i}
-                    className={`rounded-md border p-2 text-xs font-medium ${
-                      t.status === "Aceita"
-                        ? "border-green-200 bg-green-50 text-green-700"
-                        : "border-red-200 bg-red-50 text-red-700"
-                    }`}
-                  >
-                    Teste {i + 1}: {t.status}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {myStatus === "error" && (
-          <div className="space-y-2">
-            <div className="rounded-lg border border-red-200 bg-red-50 p-2.5">
-              <div className="flex items-center gap-2 text-red-700">
-                <XCircle className="h-4 w-4 shrink-0" />
-                <span className="text-xs font-semibold break-words">
-                  {myResult?.statusMessage || "Erro na execução"}
-                </span>
-              </div>
-            </div>
-            {compileError && (
-              <div className="rounded-lg border border-stone-200 bg-stone-50 p-2.5 overflow-hidden">
-                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-stone-500">
-                  <Terminal className="h-3 w-3 shrink-0" />
-                  Detalhes do erro
-                </div>
-                <pre className="whitespace-pre-wrap break-all text-[11px] text-red-600 font-mono leading-relaxed">
-                  {compileError}
-                </pre>
-              </div>
-            )}
-          </div>
-        )}
-
-        {myStatus === "submitted" && (
-          <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-2.5">
-            <div className="flex items-center gap-2 text-yellow-700">
-              <Loader2 className="h-4 w-4 animate-spin shrink-0" />
-              <span className="text-xs font-semibold">Avaliando...</span>
-            </div>
-          </div>
-        )}
-
-        {(myStatus === "joined" || myStatus === "coding") && (
-          <div className="rounded-lg border border-stone-200 bg-stone-50 p-2.5 text-xs text-stone-500">
-            Submeta seu código para ver os resultados.
-          </div>
-        )}
-
-        {/* Feedback Section */}
-        {myFeedback.length > 0 && (
-          <div>
-            <div className="mb-2 mt-1 h-px bg-stone-200" />
-            <div className="mb-2 flex items-center gap-2">
-              <MessageSquare className="h-3.5 w-3.5 shrink-0 text-stone-400" />
-              <span className="text-xs font-semibold uppercase tracking-wider text-stone-500" style={{ fontSize: "0.7rem", letterSpacing: "0.08em" }}>
-                Feedback ({myFeedback.length})
-              </span>
-            </div>
-            <div className="space-y-2">
-              {myFeedback.map((entry, i) => (
-                <div key={i} className="rounded-lg border border-stone-200 bg-stone-50 p-2.5">
-                  <p className="text-xs leading-relaxed text-stone-600 break-words">{entry.message}</p>
-                  <p className="mt-1 text-[10px] text-stone-400">
-                    {new Date(entry.created_at).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
 
 export default function JamStudentView({
   session,
@@ -278,7 +114,7 @@ export default function JamStudentView({
       {/* Header */}
       <div className="flex items-center justify-between gap-2 border-b border-stone-200 bg-white px-3 sm:px-6 py-2 sm:py-3">
         <div className="min-w-0 flex-1">
-          <h2 className="text-base sm:text-lg font-bold text-stone-800 truncate">{session.titulo}</h2>
+          <h2 className="text-sm sm:text-base font-bold text-stone-800 truncate">{session.titulo}</h2>
           <p className="text-xs sm:text-sm text-stone-500 truncate">
             Problema: {session.problema?.titulo}
           </p>
@@ -310,7 +146,7 @@ export default function JamStudentView({
             <div className="flex items-center justify-between px-5 py-3 shrink-0">
               <div className="flex items-center gap-2.5">
                 <BookOpen className="h-4 w-4 text-stone-400" />
-                <span className="text-xs font-semibold uppercase tracking-wider text-stone-500" style={{ fontSize: "0.7rem", letterSpacing: "0.08em" }}>
+                <span className="text-xs font-semibold uppercase tracking-widest text-stone-500 text-[0.7rem]">
                   Enunciado
                 </span>
               </div>
@@ -334,7 +170,7 @@ export default function JamStudentView({
             {/* Content area */}
             <div className="flex-1 overflow-y-auto px-5 py-5">
               {/* Problem title */}
-              <h2 className="mb-4 text-lg font-bold text-stone-800 leading-snug">
+              <h2 className="mb-4 text-base sm:text-lg font-bold text-stone-800 leading-snug">
                 {session.problema?.titulo || "Problema"}
               </h2>
 
@@ -352,8 +188,8 @@ export default function JamStudentView({
                 <div className="mt-6 rounded-lg border border-stone-200 bg-stone-50 p-4">
                   <div className="mb-2 flex items-center gap-2">
                     <GraduationCap className="h-3.5 w-3.5 text-stone-400" />
-                    <span className="text-xs font-semibold uppercase tracking-wider text-stone-500" style={{ letterSpacing: "0.06em" }}>
-                      Instruções do Professor
+                    <span className="text-xs font-semibold uppercase tracking-widest text-stone-500 text-[0.7rem]">
+                      Instrucoes do Professor
                     </span>
                   </div>
                   <p className="text-sm leading-relaxed text-stone-600">{session.instrucoes}</p>
@@ -374,46 +210,45 @@ export default function JamStudentView({
         {/* Code Editor */}
         <div className="flex flex-1 min-h-0 min-w-0 flex-col">
           <div className="flex items-center gap-1 sm:gap-2 border-b border-stone-200 bg-stone-50 px-2 sm:px-4 py-2 shrink-0 min-w-0">
-              <button
-                onClick={toggleProblem}
-                className={`flex items-center gap-1.5 rounded-md px-1.5 sm:px-2 py-1 text-xs font-medium transition-colors shrink-0 ${
-                  showProblem
-                    ? "bg-teal-100 text-teal-700"
-                    : "text-stone-500 hover:bg-stone-100 hover:text-stone-700"
-                }`}
-                title="Enunciado (Ctrl+E)"
-              >
-                <FileText className="h-3.5 w-3.5 shrink-0" />
-                <span className="hidden sm:inline">Enunciado</span>
-              </button>
-              <button
-                onClick={toggleResults}
-                className={`flex items-center gap-1.5 rounded-md px-1.5 sm:px-2 py-1 text-xs font-medium transition-colors shrink-0 ${
-                  showResults
-                    ? "bg-teal-100 text-teal-700"
-                    : "text-stone-500 hover:bg-stone-100 hover:text-stone-700"
-                }`}
-                title="Resultados"
-              >
-                <BarChart3 className="h-3.5 w-3.5 shrink-0" />
-                <span className="hidden sm:inline">Resultados</span>
-              </button>
-              <span className="hidden md:inline text-sm font-medium text-stone-600 truncate">Editor de Código</span>
-              <div className="flex-1" />
-              <Button
-                onClick={handleSubmit}
-                disabled={submitting || myStatus === "submitted"}
-                size="sm"
-                className="flex items-center gap-1.5 sm:gap-2 hover:opacity-90 shrink-0"
-                style={{ backgroundColor: "#0d9488" }}
-              >
-                {submitting ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Send className="h-4 w-4" />
-                )}
-                <span className="hidden sm:inline">Submeter</span>
-              </Button>
+            <button
+              onClick={toggleProblem}
+              className={`flex items-center gap-1.5 rounded-md px-1.5 sm:px-2 py-1 text-xs font-medium transition-colors shrink-0 ${
+                showProblem
+                  ? "bg-teal-100 text-teal-700"
+                  : "text-stone-500 hover:bg-stone-100 hover:text-stone-700"
+              }`}
+              title="Enunciado (Ctrl+E)"
+            >
+              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <span className="hidden sm:inline">Enunciado</span>
+            </button>
+            <button
+              onClick={toggleResults}
+              className={`flex items-center gap-1.5 rounded-md px-1.5 sm:px-2 py-1 text-xs font-medium transition-colors shrink-0 ${
+                showResults
+                  ? "bg-teal-100 text-teal-700"
+                  : "text-stone-500 hover:bg-stone-100 hover:text-stone-700"
+              }`}
+              title="Resultados"
+            >
+              <BarChart3 className="h-3.5 w-3.5 shrink-0" />
+              <span className="hidden sm:inline">Resultados</span>
+            </button>
+            <span className="hidden md:inline text-sm font-medium text-stone-600 truncate">Editor de Codigo</span>
+            <div className="flex-1" />
+            <Button
+              onClick={handleSubmit}
+              disabled={submitting || myStatus === "submitted"}
+              size="sm"
+              className="flex items-center gap-1.5 sm:gap-2 bg-teal-600 text-white hover:bg-teal-700 shrink-0"
+            >
+              {submitting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+              <span className="hidden sm:inline">Submeter</span>
+            </Button>
           </div>
           <div className="flex-1 min-h-0">
             <Editor
@@ -437,7 +272,7 @@ export default function JamStudentView({
         <div className={`absolute inset-y-0 right-0 z-20 w-full max-w-xs sm:max-w-sm overflow-y-auto border-l border-stone-200 bg-white/95 backdrop-blur-sm shadow-2xl transition-transform duration-300 ease-out ${
           showResults ? "translate-x-0" : "translate-x-full"
         }`}>
-          <ResultsPanel
+          <JamResultsPanel
             myStatus={myStatus}
             myResult={myResult}
             compileError={compileError}

--- a/front/src/pages/login/Login.tsx
+++ b/front/src/pages/login/Login.tsx
@@ -5,6 +5,9 @@ import { useUser } from "@/context/UserContext";
 import axios from "axios";
 import Notification from "@/components/Notification";
 import { Eye, EyeOff, Terminal, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 
 export default function Login() {
   const [showPassword, setShowPassword] = useState(false);
@@ -95,18 +98,11 @@ export default function Login() {
           onClose={() => setError(null)}
         />
       )}
-      <div className="fixed inset-0 flex overflow-hidden">
+      <div className="min-h-screen flex">
         {/* Left panel — brand */}
-        <div className="hidden lg:flex lg:w-[45%] bg-zinc-900 relative overflow-hidden flex-col justify-between p-12">
+        <div className="hidden lg:flex lg:w-[45%] bg-stone-900 relative overflow-hidden flex-col justify-between p-12">
           {/* Subtle grid pattern */}
-          <div
-            className="absolute inset-0 opacity-[0.04]"
-            style={{
-              backgroundImage:
-                "linear-gradient(rgba(255,255,255,.1) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.1) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-            }}
-          />
+          <div className="absolute inset-0 opacity-[0.04] bg-[linear-gradient(rgba(255,255,255,.1)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.1)_1px,transparent_1px)] bg-[size:40px_40px]" />
 
           {/* Decorative terminal lines */}
           <div className="absolute bottom-0 left-0 right-0 p-12 opacity-[0.06] font-mono text-sm text-white leading-relaxed select-none pointer-events-none">
@@ -136,7 +132,7 @@ export default function Login() {
               Pratique, submeta
               <br />e evolua.
             </h2>
-            <p className="text-zinc-400 text-sm mt-4 max-w-xs leading-relaxed">
+            <p className="text-stone-400 text-sm mt-4 max-w-xs leading-relaxed">
               Plataforma de programação para submissão e avaliação automática de
               código.
             </p>
@@ -148,19 +144,19 @@ export default function Login() {
           <div className="w-full max-w-sm">
             {/* Mobile logo */}
             <div className="flex items-center gap-2.5 mb-10 lg:hidden">
-              <div className="w-8 h-8 rounded-md bg-zinc-900 flex items-center justify-center">
+              <div className="w-8 h-8 rounded-md bg-stone-900 flex items-center justify-center">
                 <Terminal className="w-4 h-4 text-white" />
               </div>
-              <span className="text-zinc-900 text-lg font-bold tracking-tight">
+              <span className="text-stone-900 text-lg font-bold tracking-tight">
                 IFCodes
               </span>
             </div>
 
             <div className="mb-8">
-              <h1 className="text-xl font-bold text-zinc-900 tracking-tight">
+              <h1 className="text-xl font-bold text-stone-900 tracking-tight">
                 Entrar na sua conta
               </h1>
-              <p className="text-sm text-zinc-400 mt-1.5">
+              <p className="text-sm text-stone-400 mt-1.5">
                 Insira suas credenciais para acessar a plataforma.
               </p>
             </div>
@@ -168,40 +164,35 @@ export default function Login() {
             <form onSubmit={handleSubmit} className="space-y-5">
               {/* Email */}
               <div>
-                <label
-                  htmlFor="email"
-                  className="block text-sm font-medium text-zinc-700 mb-1.5"
-                >
+                <Label htmlFor="email" className="mb-1.5 text-stone-700">
                   Email
-                </label>
-                <input
+                </Label>
+                <Input
                   type="email"
                   id="email"
                   placeholder="seu@email.com"
-                  className={`w-full px-3 py-2.5 text-sm bg-white border rounded-lg outline-none transition-all ${
+                  className={
                     emailError
                       ? "border-red-400 ring-2 ring-red-100"
-                      : "border-zinc-200 focus:border-teal-500 focus:ring-2 focus:ring-teal-100"
-                  }`}
+                      : ""
+                  }
+                  aria-invalid={emailError ? true : undefined}
                   required
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   onBlur={(e) => setEmailError(validateEmail(e.target.value))}
                 />
                 {emailError && (
-                  <p className="text-red-600 text-xs mt-1.5">{emailError}</p>
+                  <p className="text-sm text-red-600 mt-1.5">{emailError}</p>
                 )}
               </div>
 
               {/* Password */}
               <div>
                 <div className="flex items-center justify-between mb-1.5">
-                  <label
-                    htmlFor="password"
-                    className="block text-sm font-medium text-zinc-700"
-                  >
+                  <Label htmlFor="password" className="text-stone-700">
                     Senha
-                  </label>
+                  </Label>
                   <Link
                     to="/forgot-password"
                     className="text-xs text-teal-600 hover:text-teal-700 font-medium transition-colors"
@@ -210,16 +201,17 @@ export default function Login() {
                   </Link>
                 </div>
                 <div className="relative">
-                  <input
+                  <Input
                     type={showPassword ? "text" : "password"}
                     id="password"
                     name="password"
                     placeholder="Sua senha"
-                    className={`w-full px-3 py-2.5 pr-10 text-sm bg-white border rounded-lg outline-none transition-all ${
+                    className={`pr-10 ${
                       passwordError
                         ? "border-red-400 ring-2 ring-red-100"
-                        : "border-zinc-200 focus:border-teal-500 focus:ring-2 focus:ring-teal-100"
+                        : ""
                     }`}
+                    aria-invalid={passwordError ? true : undefined}
                     required
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
@@ -229,7 +221,7 @@ export default function Login() {
                   />
                   <button
                     type="button"
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 transition-colors"
                     onClick={() => setShowPassword((v) => !v)}
                     title={showPassword ? "Ocultar senha" : "Mostrar senha"}
                     tabIndex={-1}
@@ -242,15 +234,16 @@ export default function Login() {
                   </button>
                 </div>
                 {passwordError && (
-                  <p className="text-red-600 text-xs mt-1.5">{passwordError}</p>
+                  <p className="text-sm text-red-600 mt-1.5">{passwordError}</p>
                 )}
               </div>
 
               {/* Submit */}
-              <button
+              <Button
                 type="submit"
                 disabled={isLoading}
-                className="w-full bg-teal-600 hover:bg-teal-700 disabled:opacity-60 disabled:cursor-not-allowed text-white text-sm font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2"
+                className="w-full"
+                size="lg"
               >
                 {isLoading ? (
                   <>
@@ -260,7 +253,7 @@ export default function Login() {
                 ) : (
                   "Entrar"
                 )}
-              </button>
+              </Button>
             </form>
           </div>
         </div>

--- a/front/src/pages/monitoring/Monitoring.tsx
+++ b/front/src/pages/monitoring/Monitoring.tsx
@@ -101,7 +101,7 @@ export default function Monitoring() {
       <ContainerGrid containers={metrics.containers} />
 
       {/* Bottom grid: Network + Queue + WebSocket */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         <NetworkStats
           rxBytes={metrics.system.net_rx_bytes}
           txBytes={metrics.system.net_tx_bytes}

--- a/front/src/pages/problems/DeleteConfirmModal.tsx
+++ b/front/src/pages/problems/DeleteConfirmModal.tsx
@@ -1,0 +1,61 @@
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface DeleteConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  problemTitle: string;
+  activitiesCount?: number;
+}
+
+export function DeleteConfirmModal({ isOpen, onClose, onConfirm, problemTitle, activitiesCount }: DeleteConfirmModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm p-4">
+      <div className="w-full max-w-md rounded-xl border border-stone-200 bg-white shadow-lg p-5 sm:p-6">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="rounded-lg bg-red-50 p-2">
+            <Trash2 className="w-6 h-6 text-red-600" />
+          </div>
+          <h3 className="text-xl font-bold text-stone-800">Confirmar Exclusao</h3>
+        </div>
+        <p className="mb-6 text-sm text-stone-500 sm:text-base">
+          Tem certeza que deseja excluir o problema{" "}
+          <span className="font-semibold text-stone-800">"{problemTitle}"</span>?
+          Esta acao nao pode ser desfeita.
+        </p>
+
+        {activitiesCount !== undefined && activitiesCount > 0 && (
+          <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4">
+            <h4 className="mb-1 flex items-center gap-2 text-sm font-semibold text-amber-800">
+              <span>Atencao: Problema em uso</span>
+            </h4>
+            <p className="text-sm text-amber-700">
+              Este problema esta atribuido a <strong>{activitiesCount}</strong> atividade{activitiesCount > 1 ? 's' : ''}.
+              Exclui-lo removera todas as atividades, submissoes e correcoes associadas.
+            </p>
+          </div>
+        )}
+
+        <div className="flex gap-3">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            className="flex-1 rounded-xl border-stone-300 text-stone-700 hover:bg-stone-50 font-medium"
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            className="flex-1 rounded-xl font-medium hover:opacity-90"
+          >
+            Confirmar Exclusao
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/problems/ProblemFormModal.tsx
+++ b/front/src/pages/problems/ProblemFormModal.tsx
@@ -1,0 +1,374 @@
+import { useState, useEffect } from "react";
+import { Plus, Trash2, X } from "lucide-react";
+import { RichTextEditor } from "@/components/RichTextEditor";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { Problem } from "@/types";
+import Notification from "@/components/Notification";
+
+export interface TestCase {
+  entrada: string;
+  saida: string;
+  privado: boolean;
+}
+
+export interface ProblemFormData {
+  titulo: string;
+  enunciado: string;
+  tempo_limite: number;
+  memoria_limite: number;
+  casos_teste: TestCase[];
+  created_by?: number;
+}
+
+interface ProblemFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: ProblemFormData) => void;
+  problem: Problem | null;
+  mode: "create" | "edit";
+}
+
+export function ProblemFormModal({ isOpen, onClose, onSave, problem, mode }: ProblemFormModalProps) {
+  const [formData, setFormData] = useState<ProblemFormData>({
+    titulo: "",
+    enunciado: "",
+    tempo_limite: 1,
+    memoria_limite: 512,
+    casos_teste: [{ entrada: "", saida: "", privado: false }]
+  });
+
+  const [errors, setErrors] = useState<{
+    titulo?: string;
+    enunciado?: string;
+    tempo_limite?: string;
+    memoria_limite?: string;
+  }>({});
+
+  const [notification, setNotification] = useState<{ type: 'success' | 'error', message: string } | null>(null);
+
+  useEffect(() => {
+    if (problem && mode === "edit") {
+      setFormData({
+        titulo: problem.title,
+        enunciado: problem.statement,
+        tempo_limite: problem.timeLimitMs,
+        memoria_limite: problem.memoryLimitKb,
+        casos_teste: problem.testCases?.map(tc => ({
+          entrada: tc.input,
+          saida: tc.expectedOutput,
+          privado: tc.private
+        })) || [{ entrada: "", saida: "", privado: false }]
+      });
+    } else {
+      setFormData({
+        titulo: "",
+        enunciado: "",
+        tempo_limite: 1000,
+        memoria_limite: 512,
+        casos_teste: [{ entrada: "", saida: "", privado: false }]
+      });
+    }
+    // Resetar erros quando o modal abrir
+    setErrors({});
+    setNotification(null);
+  }, [problem, mode, isOpen]);
+
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {};
+
+    // Validar titulo
+    if (!formData.titulo.trim()) {
+      newErrors.titulo = "O titulo e obrigatorio";
+    } else if (formData.titulo.length < 3) {
+      newErrors.titulo = "O titulo deve ter pelo menos 3 caracteres";
+    } else if (formData.titulo.length > 200) {
+      newErrors.titulo = "O titulo nao pode ter mais de 200 caracteres";
+    }
+
+    // Validar enunciado
+    let plainText = '';
+    try {
+      if (formData.enunciado) {
+        const parsed = JSON.parse(formData.enunciado);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        plainText = parsed.blocks?.map((b: any) => b.text).join('').trim() || '';
+      }
+    } catch (_e) {
+      plainText = formData.enunciado.trim();
+    }
+
+    if (!plainText) {
+      newErrors.enunciado = "O enunciado e obrigatorio";
+    } else if (plainText.length < 10) {
+      newErrors.enunciado = "O enunciado deve ter pelo menos 10 caracteres";
+    } else if (plainText.length > 10000) {
+      newErrors.enunciado = "O enunciado nao pode ter mais de 10000 caracteres";
+    }
+
+    // Validar tempo limite
+    if (!formData.tempo_limite || formData.tempo_limite < 100) {
+      newErrors.tempo_limite = "O tempo limite deve ser no minimo 100ms";
+    } else if (formData.tempo_limite > 30000) {
+      newErrors.tempo_limite = "O tempo limite nao pode ser maior que 30000ms (30s)";
+    }
+
+    // Validar memoria limite
+    if (!formData.memoria_limite || formData.memoria_limite < 128) {
+      newErrors.memoria_limite = "A memoria limite deve ser no minimo 128KB";
+    } else if (formData.memoria_limite > 1048576) {
+      newErrors.memoria_limite = "A memoria limite nao pode ser maior que 1048576KB (1GB)";
+    }
+
+    // Validar casos de teste
+    for (let i = 0; i < formData.casos_teste.length; i++) {
+      const tc = formData.casos_teste[i];
+      if (!tc.entrada.trim() || !tc.saida.trim()) {
+        setNotification({
+          type: 'error',
+          message: `Caso de teste ${i + 1}: entrada e saida sao obrigatorias`
+        });
+        return false;
+      }
+    }
+
+    setErrors(newErrors);
+
+    if (Object.keys(newErrors).length > 0) {
+      const firstError = Object.values(newErrors)[0];
+      setNotification({ type: 'error', message: firstError });
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setErrors({});
+    setNotification(null);
+    onSave(formData);
+  };
+
+  const addTestCase = () => {
+    setFormData(prev => ({
+      ...prev,
+      casos_teste: [...prev.casos_teste, { entrada: "", saida: "", privado: false }]
+    }));
+  };
+
+  const removeTestCase = (index: number) => {
+    setFormData(prev => ({
+      ...prev,
+      casos_teste: prev.casos_teste.filter((_, i) => i !== index)
+    }));
+  };
+
+  const updateTestCase = (index: number, field: keyof TestCase, value: string | boolean) => {
+    setFormData(prev => ({
+      ...prev,
+      casos_teste: prev.casos_teste.map((tc, i) =>
+        i === index ? { ...tc, [field]: value } : tc
+      )
+    }));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm p-4">
+      <div className="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl border border-stone-200 bg-white shadow-lg">
+        <div className="px-4 py-5 sm:px-6">
+          <div className="flex items-center justify-between border-b border-stone-200 pb-4">
+            <h2 className="text-xl font-bold text-stone-800">
+              {mode === "edit" ? "Editar Problema" : "Novo Problema"}
+            </h2>
+            <button
+              onClick={onClose}
+              className="rounded-lg p-2 -mr-2 text-stone-400 hover:text-stone-600 hover:bg-stone-100 transition-colors"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+
+          <form onSubmit={handleSubmit} className="mt-6 space-y-6">
+            <div>
+              <Label htmlFor="titulo" className="text-sm font-medium text-stone-600">Titulo *</Label>
+              <Input
+                id="titulo"
+                value={formData.titulo}
+                onChange={(e) => {
+                  setFormData(prev => ({ ...prev, titulo: e.target.value }));
+                  if (errors.titulo) setErrors(prev => ({ ...prev, titulo: undefined }));
+                }}
+                className={`mt-1.5 h-11 rounded-lg border-stone-300 focus-visible:ring-teal-500/30 focus-visible:border-teal-400 ${errors.titulo ? "border-red-500" : ""}`}
+                required
+              />
+              {errors.titulo && (
+                <p className="mt-1 text-sm text-red-600">{errors.titulo}</p>
+              )}
+            </div>
+
+            <div>
+              <Label htmlFor="enunciado" className="text-sm font-medium text-stone-600">Enunciado *</Label>
+              <RichTextEditor
+                value={formData.enunciado}
+                onChange={(content) => {
+                  setFormData(prev => ({ ...prev, enunciado: content }));
+                  if (errors.enunciado) setErrors(prev => ({ ...prev, enunciado: undefined }));
+                }}
+                className="mt-2"
+                maxLength={10000}
+                onError={(error) => {
+                  if (error) {
+                    setNotification({ type: 'error', message: error });
+                  }
+                }}
+                error={errors.enunciado}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="tempo_limite" className="text-sm font-medium text-stone-600">Tempo Limite (ms) *</Label>
+                <Input
+                  id="tempo_limite"
+                  type="number"
+                  min="100"
+                  max="30000"
+                  value={formData.tempo_limite}
+                  onChange={(e) => {
+                    setFormData(prev => ({ ...prev, tempo_limite: parseInt(e.target.value) || 0 }));
+                    if (errors.tempo_limite) setErrors(prev => ({ ...prev, tempo_limite: undefined }));
+                  }}
+                  className={`mt-1.5 h-11 rounded-lg border-stone-300 focus-visible:ring-teal-500/30 focus-visible:border-teal-400 ${errors.tempo_limite ? "border-red-500" : ""}`}
+                  required
+                />
+                {errors.tempo_limite && (
+                  <p className="mt-1 text-sm text-red-600">{errors.tempo_limite}</p>
+                )}
+              </div>
+
+              <div>
+                <Label htmlFor="memoria_limite" className="text-sm font-medium text-stone-600">Memoria Limite (KB) *</Label>
+                <Input
+                  id="memoria_limite"
+                  type="number"
+                  min="128"
+                  max="1048576"
+                  value={formData.memoria_limite}
+                  onChange={(e) => {
+                    setFormData(prev => ({ ...prev, memoria_limite: parseInt(e.target.value) || 0 }));
+                    if (errors.memoria_limite) setErrors(prev => ({ ...prev, memoria_limite: undefined }));
+                  }}
+                  className={`mt-1.5 h-11 rounded-lg border-stone-300 focus-visible:ring-teal-500/30 focus-visible:border-teal-400 ${errors.memoria_limite ? "border-red-500" : ""}`}
+                  required
+                />
+                {errors.memoria_limite && (
+                  <p className="mt-1 text-sm text-red-600">{errors.memoria_limite}</p>
+                )}
+              </div>
+            </div>
+
+            <div className="border-t border-stone-200 pt-6">
+              <div className="mb-4 flex items-center justify-between">
+                <Label className="text-sm font-medium text-stone-600">Casos de Teste *</Label>
+                <button
+                  type="button"
+                  onClick={addTestCase}
+                  className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium text-teal-600 bg-teal-50 hover:bg-teal-600 hover:text-white transition-colors"
+                >
+                  <Plus className="w-4 h-4" />
+                  Adicionar Caso
+                </button>
+              </div>
+
+              <div className="space-y-4">
+                {formData.casos_teste.map((testCase, index) => (
+                  <div key={index} className="rounded-xl border border-stone-200 bg-white px-3 py-3 sm:px-5 sm:py-5">
+                    <div className="mb-3 flex items-center justify-between">
+                      <h4 className="font-medium text-stone-700">Caso de Teste {index + 1}</h4>
+                      {formData.casos_teste.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={() => removeTestCase(index)}
+                          className="rounded-lg p-1.5 text-stone-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      )}
+                    </div>
+                    <div className="space-y-3">
+                      <div>
+                        <Label className="text-sm font-medium text-stone-600">Entrada</Label>
+                        <Textarea
+                          value={testCase.entrada}
+                          onChange={(e) => updateTestCase(index, 'entrada', e.target.value)}
+                          rows={3}
+                          className="mt-1.5 rounded-lg border-stone-300 focus-visible:ring-teal-500/30 focus-visible:border-teal-400"
+                          required
+                        />
+                      </div>
+                      <div>
+                        <Label className="text-sm font-medium text-stone-600">Saida Esperada</Label>
+                        <Textarea
+                          value={testCase.saida}
+                          onChange={(e) => updateTestCase(index, 'saida', e.target.value)}
+                          rows={3}
+                          className="mt-1.5 rounded-lg border-stone-300 focus-visible:ring-teal-500/30 focus-visible:border-teal-400"
+                          required
+                        />
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <input
+                          type="checkbox"
+                          id={`privado-${index}`}
+                          checked={testCase.privado}
+                          onChange={(e) => updateTestCase(index, 'privado', e.target.checked)}
+                          className="accent-teal-600"
+                        />
+                        <Label htmlFor={`privado-${index}`} className="text-sm font-medium text-stone-600">Caso de teste privado</Label>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex gap-3 pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                className="flex-1 rounded-xl border-stone-300 text-stone-700 hover:bg-stone-50 font-medium"
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                className="flex-1 rounded-xl bg-teal-600 text-white font-semibold hover:bg-teal-700"
+              >
+                {mode === "edit" ? "Atualizar" : "Criar"} Problema
+              </Button>
+            </div>
+          </form>
+
+          {notification && (
+            <Notification
+              type={notification.type}
+              message={notification.message}
+              onClose={() => setNotification(null)}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/problems/Problems.tsx
+++ b/front/src/pages/problems/Problems.tsx
@@ -1,472 +1,18 @@
 import { useState, useEffect } from "react";
-import { Plus, Trash2, X, Codesandbox, Sparkles } from "lucide-react";
+import { Plus, Codesandbox } from "lucide-react";
 import { HeroHeader } from "@/components/HeroHeader";
 import { SearchFilter } from "@/components/SearchFilter";
-import { RichTextEditor } from "@/components/RichTextEditor";
+import { EmptyState } from "@/components/EmptyState";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import { getAllProblems, createProblem, updateProblem, deleteProblem, getProblemById } from "@/services/ProblemsServices";
 import type { Problem } from "@/types";
 import Notification from "@/components/Notification";
 import { ProblemCard } from "@/components/ProblemCard";
 import { useUser } from "@/context/UserContext";
 import ProblemViewModal from "@/components/ProblemViewModal";
-
-/* ── palette tokens (inline, no global leak) ────────────────── */
-const palette = {
-  accent: "#0d9488",
-  accentLight: "#ccfbf1",
-  accentSoft: "#f0fdfa",
-  warm: "#f59e0b",
-  warmLight: "#fef3c7",
-  surface: "#fafaf9",
-  cardBg: "#ffffff",
-  textPrimary: "#1c1917",
-  textSecondary: "#78716c",
-  border: "#e7e5e4",
-  dangerText: "#dc2626",
-  dangerBg: "#fef2f2",
-};
-
-interface TestCase {
-  entrada: string;
-  saida: string;
-  privado: boolean;
-}
-
-interface ProblemFormData {
-  titulo: string;
-  enunciado: string;
-  tempo_limite: number;
-  memoria_limite: number;
-  casos_teste: TestCase[];
-  created_by?: number;
-}
-
-// Modal simples para formulario
-interface ProblemFormModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSave: (data: ProblemFormData) => void;
-  problem: Problem | null;
-  mode: "create" | "edit";
-}
-
-function ProblemFormModal({ isOpen, onClose, onSave, problem, mode }: ProblemFormModalProps) {
-  const [formData, setFormData] = useState<ProblemFormData>({
-    titulo: "",
-    enunciado: "",
-    tempo_limite: 1,
-    memoria_limite: 512,
-    casos_teste: [{ entrada: "", saida: "", privado: false }]
-  });
-
-  const [errors, setErrors] = useState<{
-    titulo?: string;
-    enunciado?: string;
-    tempo_limite?: string;
-    memoria_limite?: string;
-  }>({});
-
-  const [notification, setNotification] = useState<{ type: 'success' | 'error', message: string } | null>(null);
-
-  useEffect(() => {
-    if (problem && mode === "edit") {
-      setFormData({
-        titulo: problem.title,
-        enunciado: problem.statement,
-        tempo_limite: problem.timeLimitMs,
-        memoria_limite: problem.memoryLimitKb,
-        casos_teste: problem.testCases?.map(tc => ({
-          entrada: tc.input,
-          saida: tc.expectedOutput,
-          privado: tc.private
-        })) || [{ entrada: "", saida: "", privado: false }]
-      });
-    } else {
-      setFormData({
-        titulo: "",
-        enunciado: "",
-        tempo_limite: 1000,
-        memoria_limite: 512,
-        casos_teste: [{ entrada: "", saida: "", privado: false }]
-      });
-    }
-    // Resetar erros quando o modal abrir
-    setErrors({});
-    setNotification(null);
-  }, [problem, mode, isOpen]);
-
-  const validateForm = (): boolean => {
-    const newErrors: typeof errors = {};
-
-    // Validar titulo
-    if (!formData.titulo.trim()) {
-      newErrors.titulo = "O titulo e obrigatorio";
-    } else if (formData.titulo.length < 3) {
-      newErrors.titulo = "O titulo deve ter pelo menos 3 caracteres";
-    } else if (formData.titulo.length > 200) {
-      newErrors.titulo = "O titulo nao pode ter mais de 200 caracteres";
-    }
-
-    // Validar enunciado
-    let plainText = '';
-    try {
-      if (formData.enunciado) {
-        const parsed = JSON.parse(formData.enunciado);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        plainText = parsed.blocks?.map((b: any) => b.text).join('').trim() || '';
-      }
-    } catch (_e) {
-      plainText = formData.enunciado.trim();
-    }
-
-    if (!plainText) {
-      newErrors.enunciado = "O enunciado e obrigatorio";
-    } else if (plainText.length < 10) {
-      newErrors.enunciado = "O enunciado deve ter pelo menos 10 caracteres";
-    } else if (plainText.length > 10000) {
-      newErrors.enunciado = "O enunciado nao pode ter mais de 10000 caracteres";
-    }
-
-    // Validar tempo limite
-    if (!formData.tempo_limite || formData.tempo_limite < 100) {
-      newErrors.tempo_limite = "O tempo limite deve ser no minimo 100ms";
-    } else if (formData.tempo_limite > 30000) {
-      newErrors.tempo_limite = "O tempo limite nao pode ser maior que 30000ms (30s)";
-    }
-
-    // Validar memoria limite
-    if (!formData.memoria_limite || formData.memoria_limite < 128) {
-      newErrors.memoria_limite = "A memoria limite deve ser no minimo 128KB";
-    } else if (formData.memoria_limite > 1048576) {
-      newErrors.memoria_limite = "A memoria limite nao pode ser maior que 1048576KB (1GB)";
-    }
-
-    // Validar casos de teste
-    for (let i = 0; i < formData.casos_teste.length; i++) {
-      const tc = formData.casos_teste[i];
-      if (!tc.entrada.trim() || !tc.saida.trim()) {
-        setNotification({
-          type: 'error',
-          message: `Caso de teste ${i + 1}: entrada e saida sao obrigatorias`
-        });
-        return false;
-      }
-    }
-
-    setErrors(newErrors);
-
-    if (Object.keys(newErrors).length > 0) {
-      const firstError = Object.values(newErrors)[0];
-      setNotification({ type: 'error', message: firstError });
-      return false;
-    }
-
-    return true;
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!validateForm()) {
-      return;
-    }
-
-    setErrors({});
-    setNotification(null);
-    onSave(formData);
-  };
-
-  const addTestCase = () => {
-    setFormData(prev => ({
-      ...prev,
-      casos_teste: [...prev.casos_teste, { entrada: "", saida: "", privado: false }]
-    }));
-  };
-
-  const removeTestCase = (index: number) => {
-    setFormData(prev => ({
-      ...prev,
-      casos_teste: prev.casos_teste.filter((_, i) => i !== index)
-    }));
-  };
-
-  const updateTestCase = (index: number, field: keyof TestCase, value: string | boolean) => {
-    setFormData(prev => ({
-      ...prev,
-      casos_teste: prev.casos_teste.map((tc, i) =>
-        i === index ? { ...tc, [field]: value } : tc
-      )
-    }));
-  };
-
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
-        <div className="p-6">
-          <div className="flex items-center justify-between border-b border-stone-200 pb-4">
-            <h2 className="text-xl font-bold text-stone-900">
-              {mode === "edit" ? "Editar Problema" : "Novo Problema"}
-            </h2>
-            <button
-              onClick={onClose}
-              className="p-2 -mr-2 rounded-lg text-stone-400 hover:text-stone-600 transition-colors"
-            >
-              <X className="w-5 h-5" />
-            </button>
-          </div>
-
-          <form onSubmit={handleSubmit} className="space-y-6 mt-6">
-            <div>
-              <Label htmlFor="titulo" className="text-sm font-medium text-stone-600">Titulo *</Label>
-              <Input
-                id="titulo"
-                value={formData.titulo}
-                onChange={(e) => {
-                  setFormData(prev => ({ ...prev, titulo: e.target.value }));
-                  if (errors.titulo) setErrors(prev => ({ ...prev, titulo: undefined }));
-                }}
-                className={`mt-1.5 h-11 rounded-lg border-stone-300 focus-visible:ring-teal-500/30 focus-visible:border-teal-400 ${errors.titulo ? "border-red-500" : ""}`}
-                required
-              />
-              {errors.titulo && (
-                <p className="text-sm text-red-600 mt-1">{errors.titulo}</p>
-              )}
-            </div>
-
-            <div>
-              <Label htmlFor="enunciado" className="text-sm font-medium text-stone-600">Enunciado *</Label>
-              <RichTextEditor
-                value={formData.enunciado}
-                onChange={(content) => {
-                  setFormData(prev => ({ ...prev, enunciado: content }));
-                  if (errors.enunciado) setErrors(prev => ({ ...prev, enunciado: undefined }));
-                }}
-                className="mt-2"
-                maxLength={10000}
-                onError={(error) => {
-                  if (error) {
-                    setNotification({ type: 'error', message: error });
-                  }
-                }}
-                error={errors.enunciado}
-              />
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <Label htmlFor="tempo_limite" className="text-sm font-medium text-stone-600">Tempo Limite (ms) *</Label>
-                <Input
-                  id="tempo_limite"
-                  type="number"
-                  min="100"
-                  max="30000"
-                  value={formData.tempo_limite}
-                  onChange={(e) => {
-                    setFormData(prev => ({ ...prev, tempo_limite: parseInt(e.target.value) || 0 }));
-                    if (errors.tempo_limite) setErrors(prev => ({ ...prev, tempo_limite: undefined }));
-                  }}
-                  className={`mt-1.5 h-11 rounded-lg border-stone-300 focus-visible:ring-teal-500/30 focus-visible:border-teal-400 ${errors.tempo_limite ? "border-red-500" : ""}`}
-                  required
-                />
-                {errors.tempo_limite && (
-                  <p className="text-sm text-red-600 mt-1">{errors.tempo_limite}</p>
-                )}
-              </div>
-
-              <div>
-                <Label htmlFor="memoria_limite" className="text-sm font-medium text-stone-600">Memoria Limite (KB) *</Label>
-                <Input
-                  id="memoria_limite"
-                  type="number"
-                  min="128"
-                  max="1048576"
-                  value={formData.memoria_limite}
-                  onChange={(e) => {
-                    setFormData(prev => ({ ...prev, memoria_limite: parseInt(e.target.value) || 0 }));
-                    if (errors.memoria_limite) setErrors(prev => ({ ...prev, memoria_limite: undefined }));
-                  }}
-                  className={`mt-1.5 h-11 rounded-lg border-stone-300 focus-visible:ring-teal-500/30 focus-visible:border-teal-400 ${errors.memoria_limite ? "border-red-500" : ""}`}
-                  required
-                />
-                {errors.memoria_limite && (
-                  <p className="text-sm text-red-600 mt-1">{errors.memoria_limite}</p>
-                )}
-              </div>
-            </div>
-
-            <div className="border-t border-stone-200 pt-6">
-              <div className="flex justify-between items-center mb-4">
-                <Label className="text-sm font-medium text-stone-600">Casos de Teste *</Label>
-                <button
-                  type="button"
-                  onClick={addTestCase}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors"
-                  style={{ color: palette.accent, background: palette.accentSoft }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = palette.accent;
-                    e.currentTarget.style.color = "#fff";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = palette.accentSoft;
-                    e.currentTarget.style.color = palette.accent;
-                  }}
-                >
-                  <Plus className="w-4 h-4" />
-                  Adicionar Caso
-                </button>
-              </div>
-
-              <div className="space-y-4">
-                {formData.casos_teste.map((testCase, index) => (
-                  <div key={index} className="border border-stone-200 rounded-xl p-4">
-                    <div className="flex justify-between items-center mb-3">
-                      <h4 className="font-medium text-stone-700">Caso de Teste {index + 1}</h4>
-                      {formData.casos_teste.length > 1 && (
-                        <button
-                          type="button"
-                          onClick={() => removeTestCase(index)}
-                          className="rounded-lg p-1.5 text-stone-400 hover:text-red-600 hover:bg-red-50 transition-colors"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      )}
-                    </div>
-                    <div className="space-y-3">
-                      <div>
-                        <Label className="text-sm font-medium text-stone-600">Entrada</Label>
-                        <Textarea
-                          value={testCase.entrada}
-                          onChange={(e) => updateTestCase(index, 'entrada', e.target.value)}
-                          rows={3}
-                          className="mt-1.5 border-stone-300 rounded-lg focus-visible:ring-teal-500/30 focus-visible:border-teal-400"
-                          required
-                        />
-                      </div>
-                      <div>
-                        <Label className="text-sm font-medium text-stone-600">Saida Esperada</Label>
-                        <Textarea
-                          value={testCase.saida}
-                          onChange={(e) => updateTestCase(index, 'saida', e.target.value)}
-                          rows={3}
-                          className="mt-1.5 border-stone-300 rounded-lg focus-visible:ring-teal-500/30 focus-visible:border-teal-400"
-                          required
-                        />
-                      </div>
-                      <div className="flex items-center space-x-2">
-                        <input
-                          type="checkbox"
-                          id={`privado-${index}`}
-                          checked={testCase.privado}
-                          onChange={(e) => updateTestCase(index, 'privado', e.target.checked)}
-                          className="accent-teal-600"
-                        />
-                        <Label htmlFor={`privado-${index}`} className="text-sm font-medium text-stone-600">Caso de teste privado</Label>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <div className="flex gap-3 pt-4">
-              <button
-                type="button"
-                onClick={onClose}
-                className="flex-1 px-4 py-2.5 border border-stone-300 rounded-xl text-stone-700 hover:bg-stone-50 font-medium transition-colors"
-              >
-                Cancelar
-              </button>
-              <button
-                type="submit"
-                className="flex-1 px-4 py-2.5 text-white rounded-xl font-semibold transition-opacity hover:opacity-90"
-                style={{ backgroundColor: palette.accent }}
-              >
-                {mode === "edit" ? "Atualizar" : "Criar"} Problema
-              </button>
-            </div>
-          </form>
-
-          {notification && (
-            <Notification
-              type={notification.type}
-              message={notification.message}
-              onClose={() => setNotification(null)}
-            />
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-
-
-// Modal de confirmacao de exclusao
-interface DeleteConfirmModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
-  problemTitle: string;
-  activitiesCount?: number;
-}
-
-function DeleteConfirmModal({ isOpen, onClose, onConfirm, problemTitle, activitiesCount }: DeleteConfirmModalProps) {
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-xl max-w-md w-full p-6">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: palette.dangerBg }}>
-            <Trash2 className="w-6 h-6" style={{ color: palette.dangerText }} />
-          </div>
-          <h3 className="text-xl font-bold text-stone-900">Confirmar Exclusao</h3>
-        </div>
-        <p className="text-stone-500 mb-6">
-          Tem certeza que deseja excluir o problema{" "}
-          <span className="font-semibold text-stone-900">"{problemTitle}"</span>?
-          Esta acao nao pode ser desfeita.
-        </p>
-
-        {activitiesCount !== undefined && activitiesCount > 0 && (
-          <div className="mb-6 p-4 rounded-xl border" style={{ backgroundColor: palette.warmLight, borderColor: "#fde68a" }}>
-            <h4 className="text-sm font-semibold text-yellow-800 mb-1 flex items-center gap-2">
-              <span>Atencao: Problema em uso</span>
-            </h4>
-            <p className="text-sm text-yellow-700">
-              Este problema esta atribuido a <strong>{activitiesCount}</strong> atividade{activitiesCount > 1 ? 's' : ''}.
-              Exclui-lo removera todas as atividades, submissoes e correcoes associadas.
-            </p>
-          </div>
-        )}
-
-        <div className="flex gap-3">
-          <button
-            onClick={onClose}
-            className="flex-1 px-4 py-2.5 border border-stone-300 rounded-xl text-stone-700 hover:bg-stone-50 font-medium transition-colors"
-          >
-            Cancelar
-          </button>
-          <button
-            onClick={onConfirm}
-            className="flex-1 px-4 py-2.5 rounded-xl text-white font-medium transition-colors"
-            style={{ backgroundColor: palette.dangerText }}
-            onMouseEnter={(e) => { e.currentTarget.style.opacity = "0.9"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.opacity = "1"; }}
-          >
-            Confirmar Exclusao
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
+import { ProblemFormModal } from "./ProblemFormModal";
+import { DeleteConfirmModal } from "./DeleteConfirmModal";
+import type { ProblemFormData } from "./ProblemFormModal";
 
 export default function Problems() {
   const [problems, setProblems] = useState<Problem[]>([]);
@@ -571,32 +117,21 @@ export default function Problems() {
     setDeletingProblem(null);
   };
 
-  // Filtra problemas conforme o termo de busca
   const filteredProblems = problems.filter((problem) => {
     const searchLower = searchTerm.toLowerCase();
-    return (
-      problem.title.toLowerCase().includes(searchLower)
-    );
+    return problem.title.toLowerCase().includes(searchLower);
   });
 
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2" style={{ borderColor: palette.accent }}></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-teal-600" />
       </div>
     );
   }
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 py-3 sm:py-5 min-h-[80vh]">
-      {/* ---- scoped keyframes ---- */}
-      <style>{`
-        @keyframes problems-fade-up {
-          from { opacity: 0; transform: translateY(18px); }
-          to   { opacity: 1; transform: translateY(0); }
-        }
-      `}</style>
-
       {notification && (
         <Notification
           type={notification.type}
@@ -605,20 +140,18 @@ export default function Problems() {
         />
       )}
 
-      {/* ═══════ HERO / HEADER AREA ═══════ */}
       <HeroHeader
         icon={Codesandbox}
         title="Gerenciamento de Problemas"
-        description="Crie e gerencie problemas de programação, defina casos de teste e acompanhe as atividades."
+        description="Crie e gerencie problemas de programacao, defina casos de teste e acompanhe as atividades."
       />
 
-      {/* ═══════ SEARCH BAR + ADD BUTTON ═══════ */}
-      <div className="flex items-center gap-3 mb-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center mb-6">
         <div className="flex-1">
           <SearchFilter
             searchTerm={searchTerm}
             onSearchChange={setSearchTerm}
-            placeholder="Buscar por título do problema..."
+            placeholder="Buscar por titulo do problema..."
           />
         </div>
         <Button
@@ -629,32 +162,23 @@ export default function Problems() {
           className="shrink-0 bg-teal-600 text-white font-semibold hover:bg-teal-700 transition-colors rounded-xl px-5 h-10"
         >
           <Plus className="w-4 h-4 mr-1.5" />
-          Adicionar Problema
+          <span className="hidden sm:inline">Adicionar Problema</span>
+          <span className="sm:hidden">Adicionar</span>
         </Button>
       </div>
 
-      {/* ═══════ CARDS GRID ═══════ */}
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
-        {filteredProblems.length === 0 ? (
-          /* ── empty state ── */
-          <div className="col-span-full flex flex-col items-center justify-center py-24 text-center">
-            <div
-              className="mb-5 flex h-20 w-20 items-center justify-center rounded-2xl"
-              style={{ background: palette.accentLight }}
-            >
-              <Sparkles className="w-9 h-9" style={{ color: palette.accent }} />
-            </div>
-            <p className="text-lg font-semibold text-stone-700">
-              {searchTerm ? "Nenhum problema encontrado" : "Nenhum problema cadastrado"}
-            </p>
-            <p className="mt-1 text-sm text-stone-400 max-w-xs">
-              {searchTerm
-                ? "Tente ajustar o termo de busca."
-                : "Clique em 'Adicionar Problema' para comecar."}
-            </p>
-          </div>
-        ) : (
-          filteredProblems.map((problem, i) => (
+      {filteredProblems.length === 0 ? (
+        <EmptyState
+          title={searchTerm ? "Nenhum problema encontrado" : "Nenhum problema cadastrado"}
+          description={
+            searchTerm
+              ? "Tente ajustar o termo de busca."
+              : "Clique em 'Adicionar Problema' para comecar."
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-4">
+          {filteredProblems.map((problem, i) => (
             <ProblemCard
               key={problem.id}
               problem={problem}
@@ -663,11 +187,10 @@ export default function Problems() {
               onEdit={handleEdit}
               onDelete={handleDeleteClick}
             />
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      )}
 
-      {/* Modais */}
       <ProblemFormModal
         isOpen={isFormModalOpen}
         onClose={() => {

--- a/front/src/pages/resetPassword/ResetPassword.tsx
+++ b/front/src/pages/resetPassword/ResetPassword.tsx
@@ -5,6 +5,9 @@ import { resetPassword } from "@/services/ForgotPasswordService";
 import Notification from "@/components/Notification";
 import axios from "axios";
 import { ArrowLeft, Terminal, Loader2, Eye, EyeOff, CheckCircle2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 
 export default function ResetPassword() {
   const params = useParams();
@@ -115,17 +118,10 @@ export default function ResetPassword() {
         />
       )}
 
-      <div className="w-full min-h-screen flex">
+      <div className="min-h-screen flex">
         {/* Left panel */}
-        <div className="hidden lg:flex lg:w-[45%] bg-zinc-900 relative overflow-hidden flex-col justify-between p-12">
-          <div
-            className="absolute inset-0 opacity-[0.04]"
-            style={{
-              backgroundImage:
-                "linear-gradient(rgba(255,255,255,.1) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.1) 1px, transparent 1px)",
-              backgroundSize: "40px 40px",
-            }}
-          />
+        <div className="hidden lg:flex lg:w-[45%] bg-stone-900 relative overflow-hidden flex-col justify-between p-12">
+          <div className="absolute inset-0 opacity-[0.04] bg-[linear-gradient(rgba(255,255,255,.1)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,.1)_1px,transparent_1px)] bg-[size:40px_40px]" />
 
           <div className="relative z-10">
             <div className="flex items-center gap-3 mb-8">
@@ -144,7 +140,7 @@ export default function ResetPassword() {
               <br />
               nova senha.
             </h2>
-            <p className="text-zinc-400 text-sm mt-4 max-w-xs leading-relaxed">
+            <p className="text-stone-400 text-sm mt-4 max-w-xs leading-relaxed">
               Escolha uma senha segura com pelo menos 8 caracteres para
               proteger sua conta.
             </p>
@@ -156,10 +152,10 @@ export default function ResetPassword() {
           <div className="w-full max-w-sm">
             {/* Mobile logo */}
             <div className="flex items-center gap-2.5 mb-10 lg:hidden">
-              <div className="w-8 h-8 rounded-md bg-zinc-900 flex items-center justify-center">
+              <div className="w-8 h-8 rounded-md bg-stone-900 flex items-center justify-center">
                 <Terminal className="w-4 h-4 text-white" />
               </div>
-              <span className="text-zinc-900 text-lg font-bold tracking-tight">
+              <span className="text-stone-900 text-lg font-bold tracking-tight">
                 IFCodes
               </span>
             </div>
@@ -168,7 +164,7 @@ export default function ResetPassword() {
             <button
               type="button"
               onClick={() => navigate("/login")}
-              className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-zinc-700 transition-colors mb-8"
+              className="flex items-center gap-1.5 text-sm text-stone-400 hover:text-stone-700 transition-colors mb-8"
             >
               <ArrowLeft className="w-4 h-4" />
               Voltar para Login
@@ -180,10 +176,10 @@ export default function ResetPassword() {
                 <div className="w-12 h-12 rounded-xl bg-teal-50 flex items-center justify-center mx-auto mb-5">
                   <CheckCircle2 className="w-6 h-6 text-teal-600" />
                 </div>
-                <h1 className="text-xl font-bold text-zinc-900 tracking-tight">
+                <h1 className="text-xl font-bold text-stone-900 tracking-tight">
                   Senha redefinida
                 </h1>
-                <p className="text-sm text-zinc-400 mt-2 leading-relaxed max-w-xs mx-auto">
+                <p className="text-sm text-stone-400 mt-2 leading-relaxed max-w-xs mx-auto">
                   Sua senha foi alterada com sucesso. Você será redirecionado
                   para o login em instantes.
                 </p>
@@ -192,28 +188,25 @@ export default function ResetPassword() {
               /* Form state */
               <>
                 <div className="mb-8">
-                  <h1 className="text-xl font-bold text-zinc-900 tracking-tight">
+                  <h1 className="text-xl font-bold text-stone-900 tracking-tight">
                     Redefinir senha
                   </h1>
-                  <p className="text-sm text-zinc-400 mt-1.5">
+                  <p className="text-sm text-stone-400 mt-1.5">
                     Digite sua nova senha abaixo.
                   </p>
                 </div>
 
                 <form onSubmit={handleSubmit} className="space-y-5">
                   <div>
-                    <label
-                      htmlFor="password"
-                      className="block text-sm font-medium text-zinc-700 mb-1.5"
-                    >
+                    <Label htmlFor="password" className="mb-1.5 text-stone-700">
                       Nova senha
-                    </label>
+                    </Label>
                     <div className="relative">
-                      <input
+                      <Input
                         type={showPassword ? "text" : "password"}
                         id="password"
                         placeholder="Mínimo 8 caracteres"
-                        className="w-full px-3 py-2.5 text-sm bg-white border border-zinc-200 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring-2 focus:ring-teal-100 pr-10"
+                        className="pr-10"
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         required
@@ -221,9 +214,10 @@ export default function ResetPassword() {
                       />
                       <button
                         type="button"
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors"
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 transition-colors"
                         onClick={() => setShowPassword(!showPassword)}
                         aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
+                        tabIndex={-1}
                       >
                         {showPassword ? (
                           <EyeOff className="w-4 h-4" />
@@ -235,18 +229,15 @@ export default function ResetPassword() {
                   </div>
 
                   <div>
-                    <label
-                      htmlFor="password_confirmation"
-                      className="block text-sm font-medium text-zinc-700 mb-1.5"
-                    >
+                    <Label htmlFor="password_confirmation" className="mb-1.5 text-stone-700">
                       Confirmar nova senha
-                    </label>
+                    </Label>
                     <div className="relative">
-                      <input
+                      <Input
                         type={showConfirmPassword ? "text" : "password"}
                         id="password_confirmation"
                         placeholder="Repita a senha"
-                        className="w-full px-3 py-2.5 text-sm bg-white border border-zinc-200 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring-2 focus:ring-teal-100 pr-10"
+                        className="pr-10"
                         value={passwordConfirmation}
                         onChange={(e) =>
                           setPasswordConfirmation(e.target.value)
@@ -256,11 +247,12 @@ export default function ResetPassword() {
                       />
                       <button
                         type="button"
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors"
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 transition-colors"
                         onClick={() =>
                           setShowConfirmPassword(!showConfirmPassword)
                         }
                         aria-label={showConfirmPassword ? "Ocultar senha" : "Mostrar senha"}
+                        tabIndex={-1}
                       >
                         {showConfirmPassword ? (
                           <EyeOff className="w-4 h-4" />
@@ -271,10 +263,11 @@ export default function ResetPassword() {
                     </div>
                   </div>
 
-                  <button
+                  <Button
                     type="submit"
                     disabled={loading}
-                    className="w-full bg-teal-600 hover:bg-teal-700 disabled:opacity-60 disabled:cursor-not-allowed text-white text-sm font-medium py-2.5 rounded-lg transition-colors flex items-center justify-center gap-2"
+                    className="w-full"
+                    size="lg"
                   >
                     {loading ? (
                       <>
@@ -284,7 +277,7 @@ export default function ResetPassword() {
                     ) : (
                       "Redefinir senha"
                     )}
-                  </button>
+                  </Button>
                 </form>
               </>
             )}

--- a/front/src/pages/students/DeleteStudentModal.tsx
+++ b/front/src/pages/students/DeleteStudentModal.tsx
@@ -1,0 +1,54 @@
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export interface DeleteStudentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  studentName: string;
+}
+
+export function DeleteStudentModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  studentName,
+}: DeleteStudentModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm p-4">
+      <div className="w-full max-w-lg rounded-xl border border-stone-200 bg-white p-4 shadow-lg sm:p-6">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="rounded-lg bg-red-100 p-2">
+            <Trash2 className="h-6 w-6 text-red-600" />
+          </div>
+          <h2 className="text-xl font-bold text-stone-900">Confirmar Remoção</h2>
+        </div>
+
+        <p className="mb-6 text-sm text-stone-600 sm:text-base">
+          Tem certeza que deseja remover o aluno{" "}
+          <span className="font-semibold text-stone-900">{studentName}</span>?
+          Esta ação não pode ser desfeita.
+        </p>
+
+        <div className="flex gap-3">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            className="flex-1 rounded-xl"
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onConfirm}
+            className="flex-1 rounded-xl"
+          >
+            Confirmar Remoção
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/students/StudentFormModal.tsx
+++ b/front/src/pages/students/StudentFormModal.tsx
@@ -1,0 +1,329 @@
+import type { Student } from "@/types";
+import type { Curso } from "@/services/CoursesService";
+import { useEffect, useState } from "react";
+import {
+  Users,
+  X,
+  Mail,
+  UserCircle,
+  BookOpen,
+  IdCard,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export interface StudentFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (student: Omit<Student, "id"> | Student) => void;
+  student: Student | null;
+  mode: "create" | "edit";
+  cursos: Curso[];
+}
+
+export function StudentFormModal({
+  isOpen,
+  onClose,
+  onSave,
+  student,
+  mode,
+  cursos,
+}: StudentFormModalProps) {
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    matricula: "",
+    curso_id: "",
+    password: "",
+    password_confirmation: "",
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Atualiza o formulario quando o aluno selecionado muda
+  useEffect(() => {
+    if (student && mode === "edit") {
+      const cursoId = student.curso_id || student.curso?.id || "";
+      setFormData({
+        name: student.name,
+        email: student.email,
+        matricula: student.matricula?.toString() || "",
+        curso_id: cursoId.toString(),
+        password: "",
+        password_confirmation: "",
+      });
+    } else {
+      setFormData({
+        name: "",
+        email: "",
+        matricula: "",
+        curso_id: "",
+        password: "",
+        password_confirmation: "",
+      });
+    }
+    setErrors({});
+  }, [student, mode, isOpen]);
+
+  // Valida o email
+  const isValidEmail = (email: string) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  // Valida o formulario
+  const validateForm = () => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.name.trim()) {
+      newErrors.name = "Nome é obrigatório";
+    }
+
+    if (!formData.email.trim()) {
+      newErrors.email = "E-mail é obrigatório";
+    } else if (!isValidEmail(formData.email)) {
+      newErrors.email = "E-mail inválido";
+    }
+
+    if (!formData.matricula.trim()) {
+      newErrors.matricula = "Matrícula é obrigatória";
+    }
+
+    if (!formData.curso_id.trim()) {
+      newErrors.curso_id = "Curso é obrigatório";
+    }
+
+    if (mode === "create") {
+      if (!formData.password) {
+        newErrors.password = "Senha é obrigatória";
+      } else if (formData.password.length < 8) {
+        newErrors.password = "Senha deve ter no mínimo 8 caracteres";
+      }
+
+      if (formData.password !== formData.password_confirmation) {
+        newErrors.password_confirmation = "As senhas não coincidem";
+      }
+    } else if (mode === "edit" && formData.password) {
+      if (formData.password.length < 8) {
+        newErrors.password = "Senha deve ter no mínimo 8 caracteres";
+      }
+
+      if (formData.password !== formData.password_confirmation) {
+        newErrors.password_confirmation = "As senhas não coincidem";
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // Submete o formulario
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    const studentData: Partial<Student> = {
+      name: formData.name,
+      email: formData.email,
+      matricula: formData.matricula,
+      curso_id: parseInt(formData.curso_id),
+    };
+
+    // Adiciona senha apenas se foi preenchida
+    if (formData.password) {
+      studentData.password = formData.password;
+      studentData.password_confirmation = formData.password_confirmation;
+    }
+
+    // Adiciona ID se for edicao
+    if (mode === "edit" && student) {
+      studentData.id = student.id;
+    }
+
+    onSave(studentData as Omit<Student, "id"> | Student);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm p-4">
+      <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-xl border border-stone-200 bg-white shadow-lg">
+        {/* Header do modal */}
+        <div className="flex items-center justify-between border-b border-stone-200 px-4 py-4 sm:px-6">
+          <h2 className="text-xl font-bold text-stone-900 flex items-center gap-2">
+            <Users className="w-5 h-5 text-teal-600" />
+            {mode === "create" ? "Novo Aluno" : "Editar Aluno"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="-mr-2 rounded-lg p-2 text-stone-400 hover:text-stone-600 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Formulario */}
+        <form onSubmit={handleSubmit} className="space-y-4 px-4 py-4 sm:px-6 sm:py-5">
+          {/* Nome */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">Nome *</Label>
+            <div className="relative">
+              <UserCircle className="absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 w-5 h-5" />
+              <Input
+                type="text"
+                value={formData.name}
+                onChange={(e) =>
+                  setFormData({ ...formData, name: e.target.value })
+                }
+                className={`pl-10 ${
+                  errors.name ? "border-red-500" : ""
+                }`}
+                placeholder="Nome completo do aluno"
+              />
+            </div>
+            {errors.name && (
+              <p className="mt-1 text-xs text-red-500">{errors.name}</p>
+            )}
+          </div>
+
+          {/* E-mail */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">E-mail *</Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 w-5 h-5" />
+              <Input
+                type="email"
+                value={formData.email}
+                onChange={(e) =>
+                  setFormData({ ...formData, email: e.target.value })
+                }
+                className={`pl-10 ${
+                  errors.email ? "border-red-500" : ""
+                }`}
+                placeholder="email@exemplo.com"
+              />
+            </div>
+            {errors.email && (
+              <p className="mt-1 text-xs text-red-500">{errors.email}</p>
+            )}
+          </div>
+
+          {/* Matricula */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">Matrícula *</Label>
+            <div className="relative">
+              <IdCard className="absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 w-5 h-5" />
+              <Input
+                type="text"
+                value={formData.matricula}
+                onChange={(e) =>
+                  setFormData({ ...formData, matricula: e.target.value })
+                }
+                disabled={mode === "edit"}
+                className={`pl-10 ${
+                  mode === "edit" ? "bg-stone-100 cursor-not-allowed" : ""
+                } ${errors.matricula ? "border-red-500" : ""}`}
+                placeholder="202501001"
+              />
+            </div>
+            {errors.matricula && (
+              <p className="mt-1 text-xs text-red-500">{errors.matricula}</p>
+            )}
+          </div>
+
+          {/* Curso */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">Curso *</Label>
+            <div className="relative">
+              <BookOpen className="absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 w-5 h-5" />
+              <select
+                value={formData.curso_id}
+                onChange={(e) =>
+                  setFormData({ ...formData, curso_id: e.target.value })
+                }
+                className={`flex h-9 w-full rounded-md border bg-transparent pl-10 pr-4 py-1 text-base shadow-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] md:text-sm ${
+                  errors.curso_id ? "border-red-500" : "border-input"
+                }`}
+              >
+                <option value="">Selecione um curso</option>
+                {cursos.map((curso) => (
+                  <option key={curso.id} value={curso.id}>
+                    {curso.nome}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {errors.curso_id && (
+              <p className="mt-1 text-xs text-red-500">{errors.curso_id}</p>
+            )}
+          </div>
+
+          {/* Senha */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">
+              Senha {mode === "create" ? "*" : "(opcional)"}
+            </Label>
+            <Input
+              type="password"
+              value={formData.password}
+              onChange={(e) =>
+                setFormData({ ...formData, password: e.target.value })
+              }
+              className={errors.password ? "border-red-500" : ""}
+              placeholder="Mínimo 8 caracteres"
+            />
+            {errors.password && (
+              <p className="mt-1 text-xs text-red-500">{errors.password}</p>
+            )}
+          </div>
+
+          {/* Confirmar Senha */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">
+              Confirmar Senha {mode === "create" ? "*" : "(opcional)"}
+            </Label>
+            <Input
+              type="password"
+              value={formData.password_confirmation}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  password_confirmation: e.target.value,
+                })
+              }
+              className={errors.password_confirmation ? "border-red-500" : ""}
+              placeholder="Repita a senha"
+            />
+            {errors.password_confirmation && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.password_confirmation}
+              </p>
+            )}
+          </div>
+
+          {/* Botoes */}
+          <div className="flex gap-3 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              className="flex-1 rounded-xl"
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              className="flex-1 rounded-xl bg-teal-600 text-white hover:bg-teal-700"
+            >
+              {mode === "create" ? "Criar" : "Salvar"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/students/StudentTable.tsx
+++ b/front/src/pages/students/StudentTable.tsx
@@ -1,0 +1,101 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/table";
+import type { Student } from "@/types";
+import {
+  Pencil,
+  Trash2,
+  Mail,
+  UserCircle,
+  BookOpen,
+  IdCard,
+} from "lucide-react";
+
+export interface StudentTableProps {
+  students: Student[];
+  onEdit: (student: Student) => void;
+  onDelete: (student: Student) => void;
+}
+
+export function StudentTable({ students, onEdit, onDelete }: StudentTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="bg-stone-50 hover:bg-stone-50">
+          <TableHead className="text-sm font-semibold text-stone-900">
+            <div className="flex items-center gap-2">
+              <UserCircle className="h-4 w-4" />
+              Nome
+            </div>
+          </TableHead>
+          <TableHead className="hidden text-sm font-semibold text-stone-900 md:table-cell">
+            <div className="flex items-center gap-2">
+              <IdCard className="h-4 w-4" />
+              Matrícula
+            </div>
+          </TableHead>
+          <TableHead className="text-sm font-semibold text-stone-900">
+            <div className="flex items-center gap-2">
+              <BookOpen className="h-4 w-4" />
+              Curso
+            </div>
+          </TableHead>
+          <TableHead className="hidden text-sm font-semibold text-stone-900 md:table-cell">
+            <div className="flex items-center gap-2">
+              <Mail className="h-4 w-4" />
+              E-mail
+            </div>
+          </TableHead>
+          <TableHead className="text-center text-sm font-semibold text-stone-900 whitespace-nowrap">
+            Ações
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {students.map((student) => (
+          <TableRow
+            key={student.id}
+            className="hover:bg-stone-50 transition-colors"
+          >
+            <TableCell className="max-w-[160px] truncate text-sm font-medium text-stone-900 sm:max-w-none">
+              {student.name}
+            </TableCell>
+            <TableCell className="hidden text-sm text-stone-600 md:table-cell">
+              {student.matricula}
+            </TableCell>
+            <TableCell className="max-w-[120px] truncate text-sm text-stone-600 sm:max-w-none">
+              {student.curso?.nome ||
+                (student.curso_id ? `Curso ${student.curso_id}` : "N/A")}
+            </TableCell>
+            <TableCell className="hidden text-sm text-stone-600 md:table-cell">
+              {student.email}
+            </TableCell>
+            <TableCell>
+              <div className="flex items-center justify-center gap-2">
+                <button
+                  onClick={() => onEdit(student)}
+                  className="rounded-lg p-2.5 text-stone-400 transition-colors hover:bg-teal-50 hover:text-teal-600"
+                  title="Editar aluno"
+                >
+                  <Pencil className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => onDelete(student)}
+                  className="rounded-lg p-2.5 text-stone-400 transition-colors hover:bg-red-50 hover:text-red-600"
+                  title="Remover aluno"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/front/src/pages/students/Students.tsx
+++ b/front/src/pages/students/Students.tsx
@@ -1,12 +1,4 @@
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/table";
-import {
   getAllStudents,
   createStudent,
   updateStudent,
@@ -15,424 +7,18 @@ import {
 import { getAllCourses, type Curso } from "@/services/CoursesService";
 import type { Student } from "@/types";
 import { useEffect, useState } from "react";
-import {
-  Users,
-  Plus,
-  Pencil,
-  Trash2,
-  X,
-  Mail,
-  UserCircle,
-  BookOpen,
-  IdCard,
-  Sparkles,
-} from "lucide-react";
+import { Users, Plus } from "lucide-react";
 import Notification from "@/components/Notification";
 import Loading from "@/components/Loading";
 import { HeroHeader } from "@/components/HeroHeader";
 import { SearchFilter } from "@/components/SearchFilter";
+import { EmptyState } from "@/components/EmptyState";
+import { Button } from "@/components/ui/button";
+import { StudentFormModal } from "./StudentFormModal";
+import { DeleteStudentModal } from "./DeleteStudentModal";
+import { StudentTable } from "./StudentTable";
 
-/* ── palette tokens (inline, no global leak) ────────────────── */
-const palette = {
-  accent: "#0d9488",        // teal-600
-  accentLight: "#ccfbf1",   // teal-100
-  accentSoft: "#f0fdfa",    // teal-50
-  warm: "#f59e0b",          // amber-500
-  warmLight: "#fef3c7",     // amber-100
-  surface: "#fafaf9",       // stone-50
-  cardBg: "#ffffff",
-  textPrimary: "#1c1917",   // stone-900
-  textSecondary: "#78716c", // stone-500
-  border: "#e7e5e4",        // stone-300
-  dangerText: "#dc2626",
-  dangerBg: "#fef2f2",
-};
-
-
-// Interface para props do modal de formulário
-interface StudentFormModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSave: (student: Omit<Student, "id"> | Student) => void;
-  student: Student | null;
-  mode: "create" | "edit";
-  cursos: Curso[];
-}
-
-// Componente de modal de formulário para criar/editar aluno
-function StudentFormModal({
-  isOpen,
-  onClose,
-  onSave,
-  student,
-  mode,
-  cursos,
-}: StudentFormModalProps) {
-  const [formData, setFormData] = useState({
-    name: "",
-    email: "",
-    matricula: "",
-    curso_id: "",
-    password: "",
-    password_confirmation: "",
-  });
-
-  const [errors, setErrors] = useState<Record<string, string>>({});
-
-  // Atualiza o formulário quando o aluno selecionado muda
-  useEffect(() => {
-    if (student && mode === "edit") {
-      const cursoId = student.curso_id || student.curso?.id || "";
-      setFormData({
-        name: student.name,
-        email: student.email,
-        matricula: student.matricula?.toString() || "",
-        curso_id: cursoId.toString(),
-        password: "",
-        password_confirmation: "",
-      });
-    } else {
-      setFormData({
-        name: "",
-        email: "",
-        matricula: "",
-        curso_id: "",
-        password: "",
-        password_confirmation: "",
-      });
-    }
-    setErrors({});
-  }, [student, mode, isOpen]);
-
-  // Valida o email
-  const isValidEmail = (email: string) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-  };
-
-  // Valida o formulário
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {};
-
-    if (!formData.name.trim()) {
-      newErrors.name = "Nome é obrigatório";
-    }
-
-    if (!formData.email.trim()) {
-      newErrors.email = "E-mail é obrigatório";
-    } else if (!isValidEmail(formData.email)) {
-      newErrors.email = "E-mail inválido";
-    }
-
-    if (!formData.matricula.trim()) {
-      newErrors.matricula = "Matrícula é obrigatória";
-    }
-
-    if (!formData.curso_id.trim()) {
-      newErrors.curso_id = "Curso é obrigatório";
-    }
-
-    if (mode === "create") {
-      if (!formData.password) {
-        newErrors.password = "Senha é obrigatória";
-      } else if (formData.password.length < 8) {
-        newErrors.password = "Senha deve ter no mínimo 8 caracteres";
-      }
-
-      if (formData.password !== formData.password_confirmation) {
-        newErrors.password_confirmation = "As senhas não coincidem";
-      }
-    } else if (mode === "edit" && formData.password) {
-      if (formData.password.length < 8) {
-        newErrors.password = "Senha deve ter no mínimo 8 caracteres";
-      }
-
-      if (formData.password !== formData.password_confirmation) {
-        newErrors.password_confirmation = "As senhas não coincidem";
-      }
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  // Submete o formulário
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!validateForm()) {
-      return;
-    }
-
-    const studentData: Partial<Student> = {
-      name: formData.name,
-      email: formData.email,
-      matricula: formData.matricula,
-      curso_id: parseInt(formData.curso_id),
-    };
-
-    // Adiciona senha apenas se foi preenchida
-    if (formData.password) {
-      studentData.password = formData.password;
-      studentData.password_confirmation = formData.password_confirmation;
-    }
-
-    // Adiciona ID se for edição
-    if (mode === "edit" && student) {
-      studentData.id = student.id;
-    }
-
-    onSave(studentData as Omit<Student, "id"> | Student);
-  };
-
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
-        {/* Header do modal */}
-        <div className="flex items-center justify-between p-6 border-b border-stone-200">
-          <h2 className="text-xl font-bold text-stone-900 flex items-center gap-2">
-            <Users className="w-5 h-5 text-teal-600" />
-            {mode === "create" ? "Novo Aluno" : "Editar Aluno"}
-          </h2>
-          <button
-            onClick={onClose}
-            className="p-2 -mr-2 rounded-lg text-stone-400 hover:text-stone-600 transition-colors"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-
-        {/* Formulário */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-4">
-          {/* Nome */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Nome *
-            </label>
-            <div className="relative">
-              <UserCircle className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400 w-5 h-5" />
-              <input
-                type="text"
-                value={formData.name}
-                onChange={(e) =>
-                  setFormData({ ...formData, name: e.target.value })
-                }
-                className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                  errors.name ? "border-red-500" : "border-stone-300"
-                }`}
-                placeholder="Nome completo do aluno"
-              />
-            </div>
-            {errors.name && (
-              <p className="text-red-500 text-xs mt-1">{errors.name}</p>
-            )}
-          </div>
-
-          {/* E-mail */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              E-mail *
-            </label>
-            <div className="relative">
-              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400 w-5 h-5" />
-              <input
-                type="email"
-                value={formData.email}
-                onChange={(e) =>
-                  setFormData({ ...formData, email: e.target.value })
-                }
-                className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                  errors.email ? "border-red-500" : "border-stone-300"
-                }`}
-                placeholder="email@exemplo.com"
-              />
-            </div>
-            {errors.email && (
-              <p className="text-red-500 text-xs mt-1">{errors.email}</p>
-            )}
-          </div>
-
-          {/* Matrícula */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Matrícula *
-            </label>
-            <div className="relative">
-              <IdCard className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400 w-5 h-5" />
-              <input
-                type="text"
-                value={formData.matricula}
-                onChange={(e) =>
-                  setFormData({ ...formData, matricula: e.target.value })
-                }
-                disabled={mode === "edit"}
-                className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                  mode === "edit" ? "bg-stone-100 cursor-not-allowed" : ""
-                } ${errors.matricula ? "border-red-500" : "border-stone-300"}`}
-                placeholder="202501001"
-              />
-            </div>
-            {errors.matricula && (
-              <p className="text-red-500 text-xs mt-1">{errors.matricula}</p>
-            )}
-          </div>
-
-          {/* Curso */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Curso *
-            </label>
-            <div className="relative">
-              <BookOpen className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400 w-5 h-5" />
-              <select
-                value={formData.curso_id}
-                onChange={(e) =>
-                  setFormData({ ...formData, curso_id: e.target.value })
-                }
-                className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                  errors.curso_id ? "border-red-500" : "border-stone-300"
-                }`}
-              >
-                <option value="">Selecione um curso</option>
-                {cursos.map((curso) => (
-                  <option key={curso.id} value={curso.id}>
-                    {curso.nome}
-                  </option>
-                ))}
-              </select>
-            </div>
-            {errors.curso_id && (
-              <p className="text-red-500 text-xs mt-1">{errors.curso_id}</p>
-            )}
-          </div>
-
-          {/* Senha */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Senha {mode === "create" ? "*" : "(opcional)"}
-            </label>
-            <input
-              type="password"
-              value={formData.password}
-              onChange={(e) =>
-                setFormData({ ...formData, password: e.target.value })
-              }
-              className={`w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                errors.password ? "border-red-500" : "border-stone-300"
-              }`}
-              placeholder="Mínimo 6 caracteres"
-            />
-            {errors.password && (
-              <p className="text-red-500 text-xs mt-1">{errors.password}</p>
-            )}
-          </div>
-
-          {/* Confirmar Senha */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Confirmar Senha {mode === "create" ? "*" : "(opcional)"}
-            </label>
-            <input
-              type="password"
-              value={formData.password_confirmation}
-              onChange={(e) =>
-                setFormData({
-                  ...formData,
-                  password_confirmation: e.target.value,
-                })
-              }
-              className={`w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                errors.password_confirmation
-                  ? "border-red-500"
-                  : "border-stone-300"
-              }`}
-              placeholder="Repita a senha"
-            />
-            {errors.password_confirmation && (
-              <p className="text-red-500 text-xs mt-1">
-                {errors.password_confirmation}
-              </p>
-            )}
-          </div>
-
-          {/* Botões */}
-          <div className="flex gap-3 pt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 px-4 py-2 border border-stone-300 rounded-lg text-stone-700 hover:bg-stone-50 font-medium transition-colors"
-            >
-              Cancelar
-            </button>
-            <button
-              type="submit"
-              className="flex-1 px-4 py-2 text-white rounded-lg font-medium transition-colors hover:opacity-90"
-              style={{ backgroundColor: palette.accent }}
-            >
-              {mode === "create" ? "Criar" : "Salvar"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-// Interface para props do dialog de confirmação
-interface DeleteConfirmDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
-  studentName: string;
-}
-
-// Dialog de confirmação de remoção
-function DeleteConfirmDialog({
-  isOpen,
-  onClose,
-  onConfirm,
-  studentName,
-}: DeleteConfirmDialogProps) {
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-xl max-w-md w-full p-6">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 bg-red-100 rounded-lg">
-            <Trash2 className="w-6 h-6 text-red-600" />
-          </div>
-          <h2 className="text-xl font-bold text-stone-900">Confirmar Remoção</h2>
-        </div>
-
-        <p className="text-stone-600 mb-6">
-          Tem certeza que deseja remover o aluno{" "}
-          <span className="font-semibold text-stone-900">{studentName}</span>?
-          Esta ação não pode ser desfeita.
-        </p>
-
-        <div className="flex gap-3">
-          <button
-            onClick={onClose}
-            className="flex-1 px-4 py-2 border border-stone-300 rounded-lg text-stone-700 hover:bg-stone-50 font-medium transition-colors"
-          >
-            Cancelar
-          </button>
-          <button
-            onClick={onConfirm}
-            className="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 font-medium transition-colors"
-          >
-            Confirmar Remoção
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// Componente principal da página de gerenciamento de alunos
+// Componente principal da pagina de gerenciamento de alunos
 export default function Students() {
   const [students, setStudents] = useState<Student[]>([]);
   const [cursos, setCursos] = useState<Curso[]>([]);
@@ -454,7 +40,7 @@ export default function Students() {
     loadCursos();
   }, []);
 
-  // Função para carregar todos os cursos
+  // Funcao para carregar todos os cursos
   async function loadCursos() {
     try {
       const data = await getAllCourses();
@@ -464,7 +50,7 @@ export default function Students() {
     }
   }
 
-  // Função para carregar todos os alunos
+  // Funcao para carregar todos os alunos
   async function loadStudents() {
     setLoading(true);
     try {
@@ -481,27 +67,27 @@ export default function Students() {
     }
   }
 
-  // Abre o modal de criação
+  // Abre o modal de criacao
   function handleCreate() {
     setSelectedStudent(null);
     setModalMode("create");
     setIsModalOpen(true);
   }
 
-  // Abre o modal de edição
+  // Abre o modal de edicao
   function handleEdit(student: Student) {
     setSelectedStudent(student);
     setModalMode("edit");
     setIsModalOpen(true);
   }
 
-  // Abre o dialog de confirmação de remoção
+  // Abre o dialog de confirmacao de remocao
   function handleDeleteClick(student: Student) {
     setStudentToDelete(student);
     setIsDeleteDialogOpen(true);
   }
 
-  // Confirma a remoção do aluno
+  // Confirma a remocao do aluno
   async function confirmDelete() {
     if (!studentToDelete) return;
 
@@ -524,7 +110,7 @@ export default function Students() {
     }
   }
 
-  // Salva o aluno (criação ou edição)
+  // Salva o aluno (criacao ou edicao)
   async function handleSave(studentData: Omit<Student, "id"> | Student) {
     try {
       if (modalMode === "create") {
@@ -570,19 +156,8 @@ export default function Students() {
   });
 
   return (
-    <div className="max-w-5xl mx-auto px-4 sm:px-6 py-3 sm:py-5 min-h-[80vh]">
-      {/* ---- scoped keyframes ---- */}
-      <style>{`
-        @keyframes students-fade-up {
-          from { opacity: 0; transform: translateY(18px); }
-          to   { opacity: 1; transform: translateY(0); }
-        }
-        .stu-row {
-          animation: students-fade-up .45s cubic-bezier(.22,1,.36,1) both;
-        }
-      `}</style>
-
-      {/* Notificação */}
+    <div className="mx-auto max-w-5xl px-4 py-3 sm:px-6 sm:py-5 min-h-[80vh]">
+      {/* Notificacao */}
       {notification && (
         <Notification
           message={notification.message}
@@ -591,15 +166,15 @@ export default function Students() {
         />
       )}
 
-      {/* ═══════ HERO / HEADER AREA ═══════ */}
+      {/* Hero / Header */}
       <HeroHeader
         icon={Users}
         title="Gerenciamento de Alunos"
         description="Cadastre, edite e gerencie os alunos da plataforma."
       />
 
-      {/* ═══════ SEARCH BAR + ADD BUTTON ═══════ */}
-      <div className="flex items-center gap-3 mb-6">
+      {/* Search bar + Add button */}
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
         <div className="flex-1">
           <SearchFilter
             searchTerm={searchTerm}
@@ -607,122 +182,46 @@ export default function Students() {
             placeholder="Buscar por nome, matrícula ou e-mail..."
           />
         </div>
-        <button
+        <Button
           onClick={handleCreate}
-          className="shrink-0 flex items-center justify-center gap-2 bg-teal-600 text-white font-semibold hover:bg-teal-700 transition-colors rounded-xl px-5 h-10"
+          className="shrink-0 gap-2 rounded-xl bg-teal-600 text-white hover:bg-teal-700"
+          size="lg"
         >
-          <Plus className="w-4 h-4" />
-          Adicionar Aluno
-        </button>
+          <Plus className="h-4 w-4" />
+          <span className="hidden sm:inline">Adicionar Aluno</span>
+          <span className="sm:hidden">Adicionar</span>
+        </Button>
       </div>
 
-      {/* ═══════ TABELA DE ALUNOS ═══════ */}
-      <div
-        className="bg-white rounded-2xl border shadow-sm overflow-x-auto"
-        style={{ borderColor: palette.border }}
-      >
+      {/* Tabela de alunos */}
+      <div className="rounded-xl border border-stone-200 bg-white">
         {loading ? (
           <div className="p-6">
             <Loading />
           </div>
         ) : filteredStudents.length === 0 ? (
-          /* ── empty state ── */
-          <div className="flex flex-col items-center justify-center py-24 text-center">
-            <div
-              className="mb-5 flex h-20 w-20 items-center justify-center rounded-2xl"
-              style={{ background: palette.accentLight }}
-            >
-              <Sparkles className="w-9 h-9" style={{ color: palette.accent }} />
-            </div>
-            <p className="text-lg font-semibold text-stone-700">
-              {searchTerm
+          <EmptyState
+            title={
+              searchTerm
                 ? "Nenhum aluno encontrado"
-                : "Nenhum aluno cadastrado"}
-            </p>
-            <p className="mt-1 text-sm text-stone-400 max-w-xs">
-              {searchTerm
+                : "Nenhum aluno cadastrado"
+            }
+            description={
+              searchTerm
                 ? "Tente ajustar o termo de busca."
-                : "Clique em 'Adicionar Aluno' para começar."}
-            </p>
-          </div>
+                : "Clique em 'Adicionar Aluno' para começar."
+            }
+          />
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow className="bg-stone-50 hover:bg-stone-50">
-                <TableHead className="font-semibold text-stone-900">
-                  <div className="flex items-center gap-2">
-                    <UserCircle className="w-4 h-4" />
-                    Nome
-                  </div>
-                </TableHead>
-                <TableHead className="hidden md:table-cell font-semibold text-stone-900">
-                  <div className="flex items-center gap-2">
-                    <IdCard className="w-4 h-4" />
-                    Matrícula
-                  </div>
-                </TableHead>
-                <TableHead className="font-semibold text-stone-900">
-                  <div className="flex items-center gap-2">
-                    <BookOpen className="w-4 h-4" />
-                    Curso
-                  </div>
-                </TableHead>
-                <TableHead className="hidden md:table-cell font-semibold text-stone-900">
-                  <div className="flex items-center gap-2">
-                    <Mail className="w-4 h-4" />
-                    E-mail
-                  </div>
-                </TableHead>
-                <TableHead className="font-semibold text-stone-900 text-center whitespace-nowrap">
-                  Ações
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredStudents.map((student, i) => (
-                <TableRow
-                  key={student.id}
-                  className="stu-row hover:bg-stone-50 transition-colors duration-200"
-                  style={{ animationDelay: `${i * 60}ms` }}
-                >
-                  <TableCell className="font-medium text-stone-900 max-w-[160px] sm:max-w-none truncate">
-                    {student.name}
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell text-stone-600">
-                    {student.matricula}
-                  </TableCell>
-                  <TableCell className="text-stone-600 max-w-[120px] sm:max-w-none truncate">
-                    {student.curso?.nome || (student.curso_id ? `Curso ${student.curso_id}` : "N/A")}
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell text-stone-600">
-                    {student.email}
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center justify-center gap-2">
-                      <button
-                        onClick={() => handleEdit(student)}
-                        className="p-2.5 text-stone-400 hover:text-teal-600 hover:bg-teal-50 rounded-lg transition-colors"
-                        title="Editar aluno"
-                      >
-                        <Pencil className="w-4 h-4" />
-                      </button>
-                      <button
-                        onClick={() => handleDeleteClick(student)}
-                        className="p-2.5 text-stone-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                        title="Remover aluno"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <StudentTable
+            students={filteredStudents}
+            onEdit={handleEdit}
+            onDelete={handleDeleteClick}
+          />
         )}
       </div>
 
-      {/* Modal de formulário */}
+      {/* Modal de formulario */}
       <StudentFormModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
@@ -732,8 +231,8 @@ export default function Students() {
         cursos={cursos}
       />
 
-      {/* Dialog de confirmação de remoção */}
-      <DeleteConfirmDialog
+      {/* Dialog de confirmacao de remocao */}
+      <DeleteStudentModal
         isOpen={isDeleteDialogOpen}
         onClose={() => {
           setIsDeleteDialogOpen(false);

--- a/front/src/pages/submissions/Submissions.tsx
+++ b/front/src/pages/submissions/Submissions.tsx
@@ -165,7 +165,7 @@ export default function Submissions() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sortedSubmissions.map((submission, i) => {
+              {sortedSubmissions.map((submission) => {
                 const formattedDateOnly = new Date(
                   submission.dateSubmitted
                 ).toLocaleDateString("pt-BR", {

--- a/front/src/pages/submissions/Submissions.tsx
+++ b/front/src/pages/submissions/Submissions.tsx
@@ -22,19 +22,9 @@ import { StatusBadge, submissionStatusConfig, type SubmissionStatusKey } from "@
 import { StatCard } from "@/components/StatCard";
 import { SearchFilter } from "@/components/SearchFilter";
 import { HeroHeader } from "@/components/HeroHeader";
+import { EmptyState } from "@/components/EmptyState";
 import { useData } from "@/context/DataContext";
 import Loading from "@/components/Loading";
-
-/* ── palette tokens (inline, no global leak) ────────────────── */
-const palette = {
-  accent: "#0d9488",        // teal-600
-  accentLight: "#ccfbf1",   // teal-100
-  surface: "#fafaf9",       // stone-50
-  cardBg: "#ffffff",
-  textPrimary: "#1c1917",   // stone-900
-  textSecondary: "#78716c", // stone-500
-  border: "#e7e5e4",        // stone-300
-};
 
 
 export default function Submissions() {
@@ -88,6 +78,8 @@ export default function Submissions() {
   // Obtem os status unicos presentes para montar o filtro do select
   const uniqueStatuses = [...new Set(submissions.map((s) => s.status))];
 
+  const isFiltered = searchTerm || statusFilter !== "all";
+
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 py-3 sm:py-5 min-h-[80vh]">
       {/* ---- scoped keyframes ---- */}
@@ -134,54 +126,39 @@ export default function Submissions() {
       </div>
 
       {/* ═══════ TABLE ═══════ */}
-      <div
-        className="rounded-2xl border shadow-sm overflow-hidden"
-        style={{ background: palette.cardBg, borderColor: palette.border }}
-      >
+      <div className="rounded-xl border border-stone-200 bg-white overflow-hidden shadow-sm">
         {loading ? (
           <div className="p-6">
             <Loading />
           </div>
         ) : sortedSubmissions.length === 0 ? (
           /* ── empty state ── */
-          <div className="flex flex-col items-center justify-center py-24 text-center">
-            <div
-              className="mb-5 flex h-20 w-20 items-center justify-center rounded-2xl"
-              style={{ background: palette.accentLight }}
-            >
-              <FileText className="w-9 h-9" style={{ color: palette.accent }} />
-            </div>
-            <p className="text-lg font-semibold text-stone-700">
-              {searchTerm || statusFilter !== "all"
-                ? "Nenhuma submissao encontrada"
-                : "Nenhuma submissao ainda"}
-            </p>
-            <p className="mt-1 text-sm text-stone-400 max-w-xs">
-              {searchTerm || statusFilter !== "all"
+          <EmptyState
+            icon={FileText}
+            title={isFiltered ? "Nenhuma submissao encontrada" : "Nenhuma submissao ainda"}
+            description={
+              isFiltered
                 ? "Tente ajustar os filtros de busca."
-                : "Suas submissoes aparecerao aqui quando voce enviar solucoes."}
-            </p>
-          </div>
+                : "Suas submissoes aparecerao aqui quando voce enviar solucoes."
+            }
+          />
         ) : (
           <Table>
             <TableHeader>
-              <TableRow
-                className="hover:bg-stone-50"
-                style={{ background: palette.surface }}
-              >
-                <TableHead className="font-semibold" style={{ color: palette.textPrimary }}>
+              <TableRow className="bg-stone-50 hover:bg-stone-50">
+                <TableHead className="font-semibold text-stone-900">
                   <div className="flex items-center gap-2">
                     <Target className="w-4 h-4" />
                     Problema
                   </div>
                 </TableHead>
-                <TableHead className="hidden sm:table-cell font-semibold" style={{ color: palette.textPrimary }}>
+                <TableHead className="hidden sm:table-cell font-semibold text-stone-900">
                   <div className="flex items-center gap-2">
                     <Calendar className="w-4 h-4" />
                     Data de Submissao
                   </div>
                 </TableHead>
-                <TableHead className="font-semibold" style={{ color: palette.textPrimary }}>
+                <TableHead className="font-semibold text-stone-900">
                   Status
                 </TableHead>
                 <TableHead className="w-12"></TableHead>
@@ -207,29 +184,25 @@ export default function Submissions() {
                     key={submission.id}
                     onClick={() => redirectToSubmission(submission)}
                     className="sub-row cursor-pointer hover:bg-teal-50 transition-colors duration-200 group"
-                    style={{ animationDelay: `${i * 40}ms` }}
                   >
-                    <TableCell className="font-medium max-w-0">
+                    <TableCell className="font-medium text-sm max-w-0">
                       <div className="flex flex-col">
-                        <span
-                          className="group-hover:text-teal-600 transition-colors truncate"
-                          style={{ color: palette.textPrimary }}
-                        >
+                        <span className="text-stone-900 group-hover:text-teal-600 transition-colors truncate">
                           {problemTitle}
                         </span>
-                        <span className="text-xs mt-1 truncate" style={{ color: palette.accent }}>
+                        <span className="text-xs mt-1 text-teal-600 truncate">
                           Atividade ID: {submission.activityId} - Submissao ID: {submission.id}
                         </span>
                       </div>
                     </TableCell>
-                    <TableCell className="hidden sm:table-cell">
+                    <TableCell className="hidden sm:table-cell text-sm">
                       <div className="flex flex-col">
-                        <span className="font-medium" style={{ color: palette.textPrimary }}>
+                        <span className="font-medium text-stone-900">
                           {formattedDateOnly}
                         </span>
                       </div>
                     </TableCell>
-                    <TableCell className="whitespace-nowrap">
+                    <TableCell className="whitespace-nowrap text-sm">
                       {(() => {
                         const cfg = submissionStatusConfig[submission.status as SubmissionStatusKey] ?? submissionStatusConfig.unknown;
                         return <StatusBadge label={cfg.label} className={cfg.className} />;
@@ -248,10 +221,10 @@ export default function Submissions() {
 
       {/* Rodape com info sobre os filtros aplicados */}
       {!loading && sortedSubmissions.length > 0 && (
-        <div className="text-center text-sm mt-6" style={{ color: palette.textSecondary }}>
+        <div className="text-center text-sm mt-6 text-stone-500">
           Mostrando {sortedSubmissions.length} de {submissions.length}{" "}
           submissoes
-          {(searchTerm || statusFilter !== "all") && " (filtradas)"}
+          {isFiltered && " (filtradas)"}
         </div>
       )}
     </div>

--- a/front/src/pages/submissionsDetails/ErrorSections.tsx
+++ b/front/src/pages/submissionsDetails/ErrorSections.tsx
@@ -1,4 +1,3 @@
-import { SectionCard } from "@/components/SectionCard";
 import { AlertCircle } from "lucide-react";
 import type { TestCaseResult } from "@/types";
 

--- a/front/src/pages/submissionsDetails/ErrorSections.tsx
+++ b/front/src/pages/submissionsDetails/ErrorSections.tsx
@@ -1,0 +1,56 @@
+import { SectionCard } from "@/components/SectionCard";
+import { AlertCircle } from "lucide-react";
+import type { TestCaseResult } from "@/types";
+
+interface ErrorSectionsProps {
+  results: TestCaseResult[];
+}
+
+export function ErrorSections({ results }: ErrorSectionsProps) {
+  const hasCompileOutput = results.some((r) => r.compileOutput);
+  const hasRuntimeError =
+    !hasCompileOutput && results.some((r) => r.message || r.stderr);
+
+  return (
+    <>
+      {/* Erro de compilacao */}
+      {hasCompileOutput && (
+        <section className="rounded-xl border border-amber-200 bg-white overflow-hidden">
+          <div className="border-b border-amber-200 px-4 py-3 sm:px-6 sm:py-4 flex items-center gap-3">
+            <div className="bg-amber-50 rounded-lg p-2">
+              <AlertCircle className="w-4 h-4 text-amber-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-stone-800">
+              Saida do Compilador
+            </h2>
+          </div>
+          <div className="px-4 py-4 sm:px-6 sm:py-5">
+            <pre className="overflow-x-auto rounded-lg bg-stone-900 p-3 sm:p-4 text-sm font-mono text-stone-300 whitespace-pre-wrap max-h-80">
+              {results.find((r) => r.compileOutput)?.compileOutput}
+            </pre>
+          </div>
+        </section>
+      )}
+
+      {/* Erro de execucao (runtime error, timeout, etc.) */}
+      {hasRuntimeError && (
+        <section className="rounded-xl border border-red-200 bg-white overflow-hidden">
+          <div className="border-b border-red-200 px-4 py-3 sm:px-6 sm:py-4 flex items-center gap-3">
+            <div className="bg-red-50 rounded-lg p-2">
+              <AlertCircle className="w-4 h-4 text-red-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-stone-800">
+              Erro de Execucao
+            </h2>
+          </div>
+          <div className="px-4 py-4 sm:px-6 sm:py-5">
+            <pre className="overflow-x-auto rounded-lg bg-stone-900 p-3 sm:p-4 text-sm font-mono text-stone-300 whitespace-pre-wrap max-h-80">
+              {results.find((r) => r.message)?.message ||
+                results.find((r) => r.stderr)?.stderr}
+            </pre>
+          </div>
+        </section>
+      )}
+    </>
+  );
+}

--- a/front/src/pages/submissionsDetails/StatsCards.tsx
+++ b/front/src/pages/submissionsDetails/StatsCards.tsx
@@ -1,0 +1,91 @@
+import {
+  TestTube,
+  CheckCircle2,
+  TrendingUp,
+  XCircle,
+} from "lucide-react";
+
+interface TestStats {
+  total: number;
+  passed: number;
+  failed: number;
+  successRate: number;
+}
+
+interface StatsCardProps {
+  title: string;
+  value: string | number;
+  icon: React.ElementType;
+  iconBg: string;
+  iconColor: string;
+  description?: string;
+}
+
+function StatsCard({
+  title,
+  value,
+  icon: Icon,
+  iconBg,
+  iconColor,
+  description,
+}: StatsCardProps) {
+  return (
+    <div className="rounded-xl border border-stone-200 bg-white px-3 py-3 sm:px-5 sm:py-5">
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <p className="text-sm font-medium text-stone-600">{title}</p>
+          <p className="text-xl font-bold text-stone-900 mt-1">{value}</p>
+          {description && (
+            <p className="text-xs text-stone-500 mt-1">{description}</p>
+          )}
+        </div>
+        <div className={`rounded-lg p-2 ${iconBg}`}>
+          <Icon className={`w-5 h-5 ${iconColor}`} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface StatsCardsProps {
+  testStats: TestStats;
+}
+
+export function StatsCards({ testStats }: StatsCardsProps) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <StatsCard
+        title="Casos de Teste"
+        value={testStats.total}
+        icon={TestTube}
+        iconBg="bg-teal-50"
+        iconColor="text-teal-600"
+        description="Total de testes"
+      />
+      <StatsCard
+        title="Testes Aprovados"
+        value={testStats.passed}
+        icon={CheckCircle2}
+        iconBg="bg-emerald-50"
+        iconColor="text-emerald-600"
+        description={`${testStats.passed}/${testStats.total} passaram`}
+      />
+      <StatsCard
+        title="Taxa de Sucesso"
+        value={`${testStats.successRate}%`}
+        icon={TrendingUp}
+        iconBg="bg-amber-50"
+        iconColor="text-amber-600"
+        description="Aprovacao dos testes"
+      />
+      <StatsCard
+        title="Testes Falharam"
+        value={testStats.failed}
+        icon={XCircle}
+        iconBg="bg-red-50"
+        iconColor="text-red-600"
+        description={`${testStats.failed} falharam`}
+      />
+    </div>
+  );
+}

--- a/front/src/pages/submissionsDetails/SubmissionInfoSection.tsx
+++ b/front/src/pages/submissionsDetails/SubmissionInfoSection.tsx
@@ -1,0 +1,44 @@
+import { SectionCard } from "@/components/SectionCard";
+import { Target } from "lucide-react";
+import type { Activity, Problem } from "@/types";
+
+interface SubmissionInfoSectionProps {
+  selectedActivity: Activity;
+  selectedProblem: Problem | null;
+  formattedDueDate: string;
+}
+
+export function SubmissionInfoSection({
+  selectedActivity,
+  selectedProblem,
+  formattedDueDate,
+}: SubmissionInfoSectionProps) {
+  return (
+    <SectionCard title="Informacoes da Atividade" icon={Target}>
+      <div className="px-4 py-4 sm:px-6 sm:py-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div>
+          <label className="text-sm font-medium text-stone-500">Titulo</label>
+          <div className="mt-1 text-sm sm:text-base font-semibold text-stone-900">
+            {selectedProblem?.title || "Titulo nao encontrado"}
+          </div>
+        </div>
+        <div>
+          <label className="text-sm font-medium text-stone-500">
+            Prazo de Entrega
+          </label>
+          <div className="mt-1 text-sm sm:text-base font-semibold text-stone-900">
+            {formattedDueDate}
+          </div>
+        </div>
+        <div>
+          <label className="text-sm font-medium text-stone-500">
+            ID da Atividade
+          </label>
+          <div className="mt-1 text-sm sm:text-base font-semibold text-stone-900">
+            {selectedActivity.id}
+          </div>
+        </div>
+      </div>
+    </SectionCard>
+  );
+}

--- a/front/src/pages/submissionsDetails/SubmissionsDetails.tsx
+++ b/front/src/pages/submissionsDetails/SubmissionsDetails.tsx
@@ -1,313 +1,26 @@
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/table";
 import { getProblemById } from "@/services/ProblemsServices";
-import {
-  getResultBySubmissionId,
-} from "@/services/SubmissionsService";
-import type {
-  TestCase,
-  TestCaseResult,
-  Problem,
-} from "@/types";
+import { getResultBySubmissionId } from "@/services/SubmissionsService";
+import type { TestCaseResult, Problem } from "@/types";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import {
   ArrowLeft,
   Calendar,
-  Clock,
-  CheckCircle2,
-  XCircle,
-  AlertCircle,
   FileText,
   User,
-  Target,
-  Activity as ActivityIcon,
-  TestTube,
-  Eye,
-  EyeOff,
-  Copy,
-  Loader2,
-  TrendingUp,
   Hash,
-  Terminal,
+  AlertCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { HeroHeader } from "@/components/HeroHeader";
 import { useData } from "@/context/DataContext";
 import Loading from "@/components/Loading";
 
-// Configurações de status de testes e submissões
-const statusConfig = {
-  passed: {
-    label: "Aceito",
-    icon: CheckCircle2,
-    className: "bg-green-100 text-green-800 border-green-200",
-    dotColor: "bg-green-500",
-    bgColor: "bg-green-50",
-    borderColor: "border-green-200",
-  },
-  pending: {
-    label: "Pendente",
-    icon: Clock,
-    className: "bg-yellow-100 text-yellow-800 border-yellow-200",
-    dotColor: "bg-yellow-500",
-    bgColor: "bg-yellow-50",
-    borderColor: "border-yellow-200",
-  },
-  processing: {
-    label: "Processando",
-    icon: Loader2,
-    className: "bg-blue-100 text-blue-800 border-blue-200",
-    dotColor: "bg-blue-500",
-    bgColor: "bg-blue-50",
-    borderColor: "border-blue-200",
-  },
-  failed: {
-    label: "Resposta Errada",
-    icon: XCircle,
-    className: "bg-red-100 text-red-800 border-red-200",
-    dotColor: "bg-red-500",
-    bgColor: "bg-red-50",
-    borderColor: "border-red-200",
-  },
-  "compile-error": {
-    label: "Erro de Compilação",
-    icon: AlertCircle,
-    className: "bg-orange-100 text-orange-800 border-orange-200",
-    dotColor: "bg-orange-500",
-    bgColor: "bg-orange-50",
-    borderColor: "border-orange-200",
-  },
-  timeout: {
-    label: "Tempo Limite",
-    icon: Clock,
-    className: "bg-purple-100 text-purple-800 border-purple-200",
-    dotColor: "bg-purple-500",
-    bgColor: "bg-purple-50",
-    borderColor: "border-purple-200",
-  },
-  "runtime-error": {
-    label: "Erro de Execução",
-    icon: AlertCircle,
-    className: "bg-red-100 text-red-800 border-red-200",
-    dotColor: "bg-red-500",
-    bgColor: "bg-red-50",
-    borderColor: "border-red-200",
-  },
-  "internal-error": {
-    label: "Erro Interno",
-    icon: AlertCircle,
-    className: "bg-stone-100 text-stone-800 border-stone-200",
-    dotColor: "bg-stone-500",
-    bgColor: "bg-stone-50",
-    borderColor: "border-stone-200",
-  },
-  unknown: {
-    label: "Desconhecido",
-    icon: AlertCircle,
-    className: "bg-stone-100 text-stone-800 border-stone-200",
-    dotColor: "bg-stone-500",
-    bgColor: "bg-stone-50",
-    borderColor: "border-stone-200",
-  },
-} as const;
-
-interface StatusBadgeProps {
-  status: keyof typeof statusConfig;
-  size?: "sm" | "md" | "lg";
-}
-
-// Badge de status do teste/submissão
-function StatusBadge({ status, size = "md" }: StatusBadgeProps) {
-  const config = statusConfig[status] || statusConfig.pending;
-  const Icon = config.icon;
-
-  const sizeClasses = {
-    sm: "px-2 py-0.5 text-xs",
-    md: "px-2.5 py-1 text-xs",
-    lg: "px-3 py-1.5 text-sm",
-  };
-
-  return (
-    <span
-      className={`inline-flex items-center gap-1.5 rounded-full font-medium border ${config.className} ${sizeClasses[size]}`}
-    >
-      <div className={`w-1.5 h-1.5 rounded-full ${config.dotColor}`} />
-      <Icon className="w-3 h-3" />
-      {config.label}
-    </span>
-  );
-}
-
-// Formata a data e retorna também string relativa (ex: "2h atrás")
-function formatDate(dateString: string) {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffTime = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-  const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
-  const diffMinutes = Math.floor(diffTime / (1000 * 60));
-
-  const formatted = date.toLocaleString("pt-BR", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-
-  let relative = "";
-
-  if (diffMinutes < 1) {
-    relative = "Agora mesmo";
-  } else if (diffMinutes < 60) {
-    relative = `${diffMinutes}min atrás`;
-  } else if (diffHours < 24) {
-    relative = `${diffHours}h atrás`;
-  } else if (diffDays === 1) {
-    relative = "Ontem";
-  } else if (diffDays < 7) {
-    relative = `${diffDays} dias atrás`;
-  } else {
-    relative = `${Math.floor(diffDays / 7)} semanas atrás`;
-  }
-
-  return { formatted, relative };
-}
-
-interface TestCaseRowProps {
-  testCase: TestCase;
-  result: TestCaseResult | undefined;
-  index: number;
-}
-
-// Linha da tabela de casos de teste, com exibição/ocultação de saída e copiar para clipboard
-function TestCaseRow({ testCase, index, result }: TestCaseRowProps) {
-  const [showOutput, setShowOutput] = useState(false);
-
-  // Determina a saída real: stdout se passou, stderr se falhou
-  const actualOutput = result?.stdout || result?.stderr || "Sem saída";
-  const expectedOutput = testCase.expectedOutput || "Sem saída esperada";
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-  };
-
-  return (
-    <TableRow className="hover:bg-stone-50 transition-colors duration-200">
-      <TableCell className="font-medium">
-        <div className="flex items-center gap-2">
-          <Hash className="w-4 h-4 text-stone-400" />
-          <span>Teste {index + 1}</span>
-        </div>
-      </TableCell>
-      <TableCell>
-        <StatusBadge
-          status={result?.status as keyof typeof statusConfig || 'pending'}
-          size="sm"
-        />
-      </TableCell>
-      <TableCell>
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setShowOutput(!showOutput)}
-              className="h-6 px-2 text-xs"
-            >
-              {showOutput ? (
-                <EyeOff className="w-3 h-3" />
-              ) : (
-                <Eye className="w-3 h-3" />
-              )}
-              {showOutput ? "Ocultar" : "Mostrar"}
-            </Button>
-            {actualOutput && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => copyToClipboard(actualOutput)}
-                className="h-6 px-2 text-xs"
-              >
-                <Copy className="w-3 h-3" />
-              </Button>
-            )}
-          </div>
-          {showOutput && (
-            <div className="bg-gray-900 rounded p-2 max-w-xs">
-              <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-auto max-h-20">
-                {actualOutput}
-              </pre>
-            </div>
-          )}
-        </div>
-      </TableCell>
-      <TableCell>
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => copyToClipboard(expectedOutput)}
-              className="h-6 px-2 text-xs"
-            >
-              <Copy className="w-3 h-3" />
-              Copiar
-            </Button>
-          </div>
-          <div className="bg-gray-900 rounded p-2 max-w-xs">
-            <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-auto max-h-20">
-              {expectedOutput}
-            </pre>
-          </div>
-        </div>
-      </TableCell>
-    </TableRow>
-  );
-}
-
-interface StatsCardProps {
-  title: string;
-  value: string | number;
-  icon: React.ElementType;
-  gradient: string;
-  description?: string;
-}
-
-// Card de estatística para métricas rápidas da submissão
-function StatsCard({
-  title,
-  value,
-  icon: Icon,
-  gradient,
-  description,
-}: StatsCardProps) {
-  return (
-    <div className="bg-white p-4 rounded-lg border border-stone-200 shadow-sm">
-      <div className="flex items-center justify-between">
-        <div className="flex-1">
-          <p className="text-sm font-medium text-stone-600">{title}</p>
-          <p className="text-xl font-bold text-stone-900 mt-1">{value}</p>
-          {description && (
-            <p className="text-xs text-stone-500 mt-1">{description}</p>
-          )}
-        </div>
-        <div
-          className="p-2 rounded-lg"
-          style={{ background: gradient }}
-        >
-          <Icon className="w-5 h-5 text-white" />
-        </div>
-      </div>
-    </div>
-  );
-}
+import { StatsCards } from "./StatsCards";
+import { SubmissionInfoSection } from "./SubmissionInfoSection";
+import { ErrorSections } from "./ErrorSections";
+import { TestResultsSection } from "./TestResultsSection";
+import { formatDate } from "./utils";
 
 export default function SubmissionsDetails() {
   const params = useParams();
@@ -337,28 +50,23 @@ export default function SubmissionsDetails() {
     return mapSubmissions.get(Number(submissionId));
   }, [submissionId, mapSubmissions]);
 
-  // Tenta pegar do cache primeiro, senão usa o fetchedProblem
+  // Tenta pegar do cache primeiro, senao usa o fetchedProblem
   const selectedProblem = useMemo(() => {
     const fromCache = mapProblems.get(Number(selectedActivity?.problemId));
     return fromCache || fetchedProblem;
   }, [selectedActivity, mapProblems, fetchedProblem]);
 
-  // Cálculo de estatísticas dos casos de teste baseado nos resultados reais
+  // Calculo de estatisticas dos casos de teste baseado nos resultados reais
   // IMPORTANTE: Este useMemo deve estar ANTES de qualquer return condicional (regras dos Hooks)
   const testStats = useMemo(() => {
     if (!selectedProblem?.testCases || selectedProblem.testCases.length === 0) {
-      return {
-        total: 0,
-        passed: 0,
-        failed: 0,
-        successRate: 0,
-      };
+      return { total: 0, passed: 0, failed: 0, successRate: 0 };
     }
 
     const total = selectedProblem.testCases.length;
     const passed = selectedProblem.testCases.filter((tc) => {
       const result = mapResultByTestId.get(tc.id);
-      return result?.status === 'passed';
+      return result?.status === "passed";
     }).length;
     const failed = total - passed;
     const successRate = total > 0 ? Math.round((passed / total) * 100) : 0;
@@ -367,7 +75,6 @@ export default function SubmissionsDetails() {
   }, [selectedProblem, mapResultByTestId]);
 
   useEffect(() => {
-    // Busca detalhes da submissão, relatório e atividade relacionada
     const fetchData = async () => {
       if (!submissionId) return;
 
@@ -376,7 +83,6 @@ export default function SubmissionsDetails() {
         const submissionResult = await getResultBySubmissionId(
           Number(submissionId)
         );
-
         setResults(submissionResult);
       } catch (error) {
         console.error("Failed to fetch submission details:", error);
@@ -387,7 +93,7 @@ export default function SubmissionsDetails() {
     fetchData();
   }, [submissionId]);
 
-  // Busca o problema separadamente quando a atividade estiver disponível
+  // Busca o problema separadamente quando a atividade estiver disponivel
   useEffect(() => {
     if (selectedActivity && !mapProblems.get(selectedActivity.problemId)) {
       getProblemById(String(selectedActivity.problemId)).then((problem) => {
@@ -396,32 +102,31 @@ export default function SubmissionsDetails() {
         }
       });
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedActivity?.problemId]);
 
   if (loading) {
     return (
-      <div className="max-w-7xl mx-auto p-6">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-6">
         <Loading />
       </div>
     );
   }
 
-  // Exibe mensagem caso algum dado essencial não seja encontrado
   if (!selectedActivity || !submission) {
     return (
-      <div className="max-w-7xl mx-auto p-6">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-6">
         <div className="text-center py-12">
-          <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+          <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <h2 className="text-xl font-semibold text-stone-900 mb-2">
-            Submissão não encontrada
+            Submissao nao encontrada
           </h2>
-          <p className="text-stone-600 mb-4">
-            A submissão solicitada não existe ou não pôde ser carregada.
+          <p className="text-sm text-stone-600 mb-4">
+            A submissao solicitada nao existe ou nao pode ser carregada.
           </p>
           <Button onClick={() => navigate("/submissions")} variant="outline">
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Voltar às submissões
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Voltar as submissoes
           </Button>
         </div>
       </div>
@@ -440,260 +145,62 @@ export default function SubmissionsDetails() {
   });
 
   return (
-    <div className="max-w-7xl mx-auto p-6 space-y-8">
-      {/* Header de navegação */}
-      <div className="flex items-center gap-4 mb-6">
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 space-y-6 pb-10">
+      {/* Back button */}
+      <div className="flex items-center gap-4 pt-4 sm:pt-6">
         <Button
           variant="ghost"
           size="sm"
           onClick={() => navigate("/submissions")}
           className="flex items-center gap-2"
         >
-          <ArrowLeft className="w-4 h-4" />
+          <ArrowLeft className="h-4 w-4" />
           Voltar
         </Button>
       </div>
 
-      {/* Hero header da submissão */}
-      <div
-        className="relative rounded-2xl px-8 py-10 text-white overflow-hidden"
-        style={{ background: "linear-gradient(135deg, #0d9488 0%, #065f46 100%)" }}
-      >
-        {/* Decorative circles */}
-        <div
-          className="absolute -top-10 -right-10 w-48 h-48 rounded-full"
-          style={{ background: "rgba(255,255,255,0.1)" }}
-        />
-        <div
-          className="absolute -bottom-8 -left-8 w-36 h-36 rounded-full"
-          style={{ background: "rgba(255,255,255,0.07)" }}
-        />
-
-        <div className="relative flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-          <div className="flex-1">
-            <div className="flex items-center gap-2 mb-2">
-              <FileText className="w-6 h-6" />
-              <span className="text-teal-100 text-sm font-medium">
-                Detalhes da Submissão
+      {/* Hero header */}
+      <HeroHeader
+        icon={FileText}
+        title={selectedProblem?.title || "Problema nao encontrado"}
+        description={
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-6">
+            <div className="flex items-center gap-4 text-teal-100">
+              <span className="inline-flex items-center gap-1">
+                <User className="h-4 w-4" />
+                <span className="text-sm">Usuario</span>
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <Hash className="h-4 w-4" />
+                <span className="text-sm">ID: {submission.id}</span>
               </span>
             </div>
-            <h1 className="text-3xl font-extrabold tracking-tight mb-2">
-              {selectedProblem?.title || "Problema não encontrado"}
-            </h1>
-            <div className="flex items-center gap-4 text-teal-100">
-              <div className="flex items-center gap-1">
-                <User className="w-4 h-4" />
-                <span>Usuário</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <Hash className="w-4 h-4" />
-                <span>ID: {submission.id}</span>
-              </div>
+            <div className="inline-flex items-center gap-1 text-teal-100">
+              <Calendar className="h-4 w-4" />
+              <span className="text-sm">Enviado em: {formattedSubmissionDateOnly}</span>
             </div>
           </div>
+        }
+      />
 
-          <div className="flex flex-col sm:flex-row gap-4">
-            <div className="bg-white/10 backdrop-blur-sm rounded-lg p-4 text-center">
-              <Calendar className="w-5 h-5 mx-auto mb-1" />
-              <div className="text-sm font-medium">Enviado em</div>
-              <div className="text-lg font-bold">
-                {formattedSubmissionDateOnly}
-              </div>
-              {/* relativa removida - não exibir 'Agora mesmo' nem '7h atrás' */}
-            </div>
-          </div>
-        </div>
-      </div>
+      {/* Stats */}
+      <StatsCards testStats={testStats} />
 
-      {/* Cards de estatísticas rápidas (casos de teste) */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatsCard
-          title="Casos de Teste"
-          value={testStats.total}
-          icon={TestTube}
-          gradient="linear-gradient(135deg, #0d9488 0%, #0f766e 100%)"
-          description="Total de testes"
-        />
-        <StatsCard
-          title="Testes Aprovados"
-          value={testStats.passed}
-          icon={CheckCircle2}
-          gradient="linear-gradient(135deg, #10b981 0%, #059669 100%)"
-          description={`${testStats.passed}/${testStats.total} passaram`}
-        />
-        <StatsCard
-          title="Taxa de Sucesso"
-          value={`${testStats.successRate}%`}
-          icon={TrendingUp}
-          gradient="linear-gradient(135deg, #f59e0b 0%, #d97706 100%)"
-          description="Aprovação dos testes"
-        />
-        <StatsCard
-          title="Testes Falharam"
-          value={testStats.failed}
-          icon={XCircle}
-          gradient="linear-gradient(135deg, #ef4444 0%, #dc2626 100%)"
-          description={`${testStats.failed} falharam`}
-        />
-      </div>
+      {/* Activity info */}
+      <SubmissionInfoSection
+        selectedActivity={selectedActivity}
+        selectedProblem={selectedProblem}
+        formattedDueDate={dueDate.formatted}
+      />
 
-      {/* Informações da atividade */}
-      <div className="bg-white rounded-lg border border-stone-200 shadow-sm">
-        <div className="border-b border-stone-200 p-6">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-teal-50 rounded-lg">
-              <Target className="w-5 h-5 text-teal-600" />
-            </div>
-            <h2 className="text-2xl font-bold text-stone-800">
-              Informações da Atividade
-            </h2>
-          </div>
-        </div>
+      {/* Compile / runtime errors */}
+      <ErrorSections results={results} />
 
-        <div className="p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="text-sm font-medium text-stone-600">Titulo</label>
-            <div className="mt-1">
-              <div className="text-lg font-semibold text-stone-900">
-                {selectedProblem?.title || "Título não encontrado"}
-              </div>
-            </div>
-          </div>
-          <div>
-            <label className="text-sm font-medium text-stone-600">
-              Prazo de Entrega
-            </label>
-            <div className="mt-1">
-                <div className="text-lg font-semibold text-stone-900">
-                  {dueDate.formatted}
-                </div>
-              </div>
-          </div>
-          <div>
-            <label className="text-sm font-medium text-stone-600">
-              ID da Atividade
-            </label>
-            <div className="mt-1 text-lg font-semibold text-stone-900">
-              {selectedActivity.id}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Erro de compilação */}
-      {results.some((r) => r.compileOutput) && (
-        <div className="bg-white rounded-lg border border-orange-200 shadow-sm">
-          <div className="border-b border-orange-200 p-6">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-orange-50 rounded-lg">
-                <AlertCircle className="w-5 h-5 text-orange-600" />
-              </div>
-              <h2 className="text-2xl font-bold text-stone-800">
-                Saída do Compilador
-              </h2>
-            </div>
-          </div>
-          <div className="p-6">
-            <pre className="bg-gray-900 text-gray-300 rounded-lg p-4 text-sm font-mono whitespace-pre-wrap overflow-auto max-h-80">
-              {results.find((r) => r.compileOutput)?.compileOutput}
-            </pre>
-          </div>
-        </div>
-      )}
-
-      {/* Erro de execução (runtime error, timeout, etc.) */}
-      {!results.some((r) => r.compileOutput) && results.some((r) => r.message || r.stderr) && (
-        <div className="bg-white rounded-lg border border-red-200 shadow-sm">
-          <div className="border-b border-red-200 p-6">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-red-50 rounded-lg">
-                <AlertCircle className="w-5 h-5 text-red-600" />
-              </div>
-              <h2 className="text-2xl font-bold text-stone-800">
-                Erro de Execução
-              </h2>
-            </div>
-          </div>
-          <div className="p-6">
-            <pre className="bg-gray-900 text-gray-300 rounded-lg p-4 text-sm font-mono whitespace-pre-wrap overflow-auto max-h-80">
-              {results.find((r) => r.message)?.message || results.find((r) => r.stderr)?.stderr}
-            </pre>
-          </div>
-        </div>
-      )}
-
-      {/* Casos de teste da submissão */}
-      <div className="bg-white rounded-lg border border-stone-200 shadow-sm">
-        <div className="border-b border-stone-200 p-6">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-emerald-50 rounded-lg">
-                <TestTube className="w-5 h-5 text-emerald-600" />
-              </div>
-              <h2 className="text-2xl font-bold text-stone-800">
-                Casos de Teste
-              </h2>
-            </div>
-          </div>
-        </div>
-
-        <div className="p-6">
-          {selectedProblem?.testCases?.length === 0 ? (
-            <div className="text-center py-8">
-              <TestTube className="w-12 h-12 text-stone-400 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-stone-900 mb-2">
-                Nenhum caso de teste
-              </h3>
-              <p className="text-stone-500">
-                Esta submissão não possui casos de teste para exibir
-              </p>
-            </div>
-          ) : (
-            <div className="overflow-hidden">
-              <Table>
-                <TableHeader>
-                  <TableRow className="bg-stone-50 hover:bg-stone-50">
-                    <TableHead className="font-semibold text-stone-800">
-                      <div className="flex items-center gap-2">
-                        <Hash className="w-4 h-4" />
-                        Teste
-                      </div>
-                    </TableHead>
-                    <TableHead className="font-semibold text-stone-800">
-                      <div className="flex items-center gap-2">
-                        <ActivityIcon className="w-4 h-4" />
-                        Status
-                      </div>
-                    </TableHead>
-                    <TableHead className="font-semibold text-stone-800">
-                      <div className="flex items-center gap-2">
-                        <Terminal className="w-4 h-4" />
-                        Saída Atual
-                      </div>
-                    </TableHead>
-                    <TableHead className="font-semibold text-stone-800">
-                      <div className="flex items-center gap-2">
-                        <Target className="w-4 h-4" />
-                        Saída Esperada
-                      </div>
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {selectedProblem?.testCases?.map((testCase, index) => (
-                    <TestCaseRow
-                      key={testCase.id}
-                      testCase={testCase}
-                      result={mapResultByTestId.get(testCase.id)}
-                      index={index}
-                    />
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </div>
-      </div>
+      {/* Test cases table */}
+      <TestResultsSection
+        testCases={selectedProblem?.testCases}
+        mapResultByTestId={mapResultByTestId}
+      />
     </div>
   );
 }

--- a/front/src/pages/submissionsDetails/TestResultsSection.tsx
+++ b/front/src/pages/submissionsDetails/TestResultsSection.tsx
@@ -1,0 +1,208 @@
+import { useState } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/table";
+import { SectionCard } from "@/components/SectionCard";
+import { Button } from "@/components/ui/button";
+import {
+  Hash,
+  Eye,
+  EyeOff,
+  Copy,
+  TestTube,
+  Terminal,
+  Target,
+  Activity as ActivityIcon,
+} from "lucide-react";
+import type { TestCase, TestCaseResult } from "@/types";
+import { testStatusConfig, type TestStatusKey } from "./statusConfig";
+
+/* ── Inline test status badge ─────────────────────── */
+
+interface TestBadgeProps {
+  status: TestStatusKey;
+}
+
+function TestBadge({ status }: TestBadgeProps) {
+  const config = testStatusConfig[status] || testStatusConfig.pending;
+  const Icon = config.icon;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${config.className}`}
+    >
+      <div className={`h-1.5 w-1.5 rounded-full ${config.dotColor}`} />
+      <Icon className="h-3 w-3" />
+      {config.label}
+    </span>
+  );
+}
+
+/* ── Single test-case row ─────────────────────────── */
+
+interface TestCaseRowProps {
+  testCase: TestCase;
+  result: TestCaseResult | undefined;
+  index: number;
+}
+
+function TestCaseRow({ testCase, index, result }: TestCaseRowProps) {
+  const [showOutput, setShowOutput] = useState(false);
+
+  const actualOutput = result?.stdout || result?.stderr || "Sem saida";
+  const expectedOutput = testCase.expectedOutput || "Sem saida esperada";
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+  };
+
+  return (
+    <TableRow className="hover:bg-stone-50 transition-colors">
+      <TableCell className="font-medium">
+        <div className="flex items-center gap-2">
+          <Hash className="h-4 w-4 text-stone-400" />
+          <span className="text-sm">Teste {index + 1}</span>
+        </div>
+      </TableCell>
+      <TableCell>
+        <TestBadge
+          status={(result?.status as TestStatusKey) || "pending"}
+        />
+      </TableCell>
+      <TableCell>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowOutput(!showOutput)}
+              className="h-6 px-2 text-xs"
+            >
+              {showOutput ? (
+                <EyeOff className="h-3 w-3" />
+              ) : (
+                <Eye className="h-3 w-3" />
+              )}
+              {showOutput ? "Ocultar" : "Mostrar"}
+            </Button>
+            {actualOutput && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => copyToClipboard(actualOutput)}
+                className="h-6 px-2 text-xs"
+              >
+                <Copy className="h-3 w-3" />
+              </Button>
+            )}
+          </div>
+          {showOutput && (
+            <div className="overflow-x-auto rounded bg-stone-900 p-2 max-w-xs">
+              <pre className="text-xs text-stone-300 whitespace-pre-wrap max-h-20 overflow-auto">
+                {actualOutput}
+              </pre>
+            </div>
+          )}
+        </div>
+      </TableCell>
+      <TableCell>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => copyToClipboard(expectedOutput)}
+              className="h-6 px-2 text-xs"
+            >
+              <Copy className="h-3 w-3" />
+              Copiar
+            </Button>
+          </div>
+          <div className="overflow-x-auto rounded bg-stone-900 p-2 max-w-xs">
+            <pre className="text-xs text-stone-300 whitespace-pre-wrap max-h-20 overflow-auto">
+              {expectedOutput}
+            </pre>
+          </div>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+/* ── Full test-results section ────────────────────── */
+
+interface TestResultsSectionProps {
+  testCases: TestCase[] | undefined;
+  mapResultByTestId: Map<number, TestCaseResult>;
+}
+
+export function TestResultsSection({
+  testCases,
+  mapResultByTestId,
+}: TestResultsSectionProps) {
+  return (
+    <SectionCard title="Casos de Teste" icon={TestTube}>
+      <div className="px-4 py-4 sm:px-6 sm:py-5">
+        {!testCases || testCases.length === 0 ? (
+          <div className="text-center py-8">
+            <TestTube className="h-12 w-12 text-stone-400 mx-auto mb-4" />
+            <h3 className="text-base font-medium text-stone-900 mb-2">
+              Nenhum caso de teste
+            </h3>
+            <p className="text-sm text-stone-500">
+              Esta submissao nao possui casos de teste para exibir
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-stone-50 hover:bg-stone-50">
+                  <TableHead className="font-semibold text-stone-800">
+                    <div className="flex items-center gap-2">
+                      <Hash className="h-4 w-4" />
+                      Teste
+                    </div>
+                  </TableHead>
+                  <TableHead className="font-semibold text-stone-800">
+                    <div className="flex items-center gap-2">
+                      <ActivityIcon className="h-4 w-4" />
+                      Status
+                    </div>
+                  </TableHead>
+                  <TableHead className="font-semibold text-stone-800">
+                    <div className="flex items-center gap-2">
+                      <Terminal className="h-4 w-4" />
+                      Saida Atual
+                    </div>
+                  </TableHead>
+                  <TableHead className="font-semibold text-stone-800">
+                    <div className="flex items-center gap-2">
+                      <Target className="h-4 w-4" />
+                      Saida Esperada
+                    </div>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {testCases.map((testCase, index) => (
+                  <TestCaseRow
+                    key={testCase.id}
+                    testCase={testCase}
+                    result={mapResultByTestId.get(testCase.id)}
+                    index={index}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </SectionCard>
+  );
+}

--- a/front/src/pages/submissionsDetails/statusConfig.ts
+++ b/front/src/pages/submissionsDetails/statusConfig.ts
@@ -1,0 +1,66 @@
+import {
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Clock,
+  Loader2,
+} from "lucide-react";
+
+export const testStatusConfig = {
+  passed: {
+    label: "Aceito",
+    icon: CheckCircle2,
+    className: "bg-emerald-50 text-emerald-700 border-emerald-200",
+    dotColor: "bg-emerald-500",
+  },
+  pending: {
+    label: "Pendente",
+    icon: Clock,
+    className: "bg-amber-50 text-amber-700 border-amber-200",
+    dotColor: "bg-amber-500",
+  },
+  processing: {
+    label: "Processando",
+    icon: Loader2,
+    className: "bg-stone-50 text-stone-600 border-stone-200",
+    dotColor: "bg-stone-500",
+  },
+  failed: {
+    label: "Resposta Errada",
+    icon: XCircle,
+    className: "bg-red-50 text-red-700 border-red-200",
+    dotColor: "bg-red-500",
+  },
+  "compile-error": {
+    label: "Erro de Compilacao",
+    icon: AlertCircle,
+    className: "bg-amber-50 text-amber-700 border-amber-200",
+    dotColor: "bg-amber-500",
+  },
+  timeout: {
+    label: "Tempo Limite",
+    icon: Clock,
+    className: "bg-amber-50 text-amber-700 border-amber-200",
+    dotColor: "bg-amber-500",
+  },
+  "runtime-error": {
+    label: "Erro de Execucao",
+    icon: AlertCircle,
+    className: "bg-red-50 text-red-700 border-red-200",
+    dotColor: "bg-red-500",
+  },
+  "internal-error": {
+    label: "Erro Interno",
+    icon: AlertCircle,
+    className: "bg-stone-100 text-stone-600 border-stone-200",
+    dotColor: "bg-stone-500",
+  },
+  unknown: {
+    label: "Desconhecido",
+    icon: AlertCircle,
+    className: "bg-stone-100 text-stone-600 border-stone-200",
+    dotColor: "bg-stone-500",
+  },
+} as const;
+
+export type TestStatusKey = keyof typeof testStatusConfig;

--- a/front/src/pages/submissionsDetails/utils.ts
+++ b/front/src/pages/submissionsDetails/utils.ts
@@ -1,0 +1,35 @@
+// Formata a data e retorna tambem string relativa (ex: "2h atras")
+export function formatDate(dateString: string) {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffTime = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+  const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
+  const diffMinutes = Math.floor(diffTime / (1000 * 60));
+
+  const formatted = date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  let relative = "";
+
+  if (diffMinutes < 1) {
+    relative = "Agora mesmo";
+  } else if (diffMinutes < 60) {
+    relative = `${diffMinutes}min atras`;
+  } else if (diffHours < 24) {
+    relative = `${diffHours}h atras`;
+  } else if (diffDays === 1) {
+    relative = "Ontem";
+  } else if (diffDays < 7) {
+    relative = `${diffDays} dias atras`;
+  } else {
+    relative = `${Math.floor(diffDays / 7)} semanas atras`;
+  }
+
+  return { formatted, relative };
+}

--- a/front/src/pages/teachers/DeleteTeacherModal.tsx
+++ b/front/src/pages/teachers/DeleteTeacherModal.tsx
@@ -1,0 +1,60 @@
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export interface DeleteTeacherModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  professorName: string;
+}
+
+export function DeleteTeacherModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  professorName,
+}: DeleteTeacherModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm p-4">
+      <div className="w-full max-w-md rounded-xl border border-stone-200 bg-white p-4 shadow-lg sm:p-6">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="rounded-lg bg-red-50 p-2">
+            <Trash2 className="h-6 w-6 text-red-600" />
+          </div>
+          <h2 className="text-xl font-bold text-stone-900">
+            Confirmar Remoção
+          </h2>
+        </div>
+
+        <p className="mb-6 text-sm text-stone-500 sm:text-base">
+          Tem certeza que deseja remover o professor{" "}
+          <span className="font-semibold text-stone-900">
+            {professorName}
+          </span>
+          ? Esta ação não pode ser desfeita.
+        </p>
+
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            className="flex-1 rounded-xl border-stone-300 text-stone-700 hover:bg-stone-50"
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onConfirm}
+            className="flex-1 rounded-xl"
+          >
+            Confirmar Remoção
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/teachers/TeacherFormModal.tsx
+++ b/front/src/pages/teachers/TeacherFormModal.tsx
@@ -1,0 +1,294 @@
+import type { Professor } from "@/types";
+import { useEffect, useState } from "react";
+import {
+  GraduationCap,
+  X,
+  Mail,
+  UserCircle,
+  Briefcase,
+} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+export interface TeacherFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (professor: Omit<Professor, "id"> | Professor) => void;
+  professor: Professor | null;
+  mode: "create" | "edit";
+}
+
+export function TeacherFormModal({
+  isOpen,
+  onClose,
+  onSave,
+  professor,
+  mode,
+}: TeacherFormModalProps) {
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    area_atuacao: "",
+    password: "",
+    password_confirmation: "",
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Atualiza o formulario quando o professor selecionado muda
+  useEffect(() => {
+    if (professor && mode === "edit") {
+      setFormData({
+        name: professor.name,
+        email: professor.email,
+        area_atuacao: professor.area_atuacao,
+        password: "",
+        password_confirmation: "",
+      });
+    } else {
+      setFormData({
+        name: "",
+        email: "",
+        area_atuacao: "",
+        password: "",
+        password_confirmation: "",
+      });
+    }
+    setErrors({});
+  }, [professor, mode, isOpen]);
+
+  // Valida o email
+  const isValidEmail = (email: string) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  // Valida o formulario
+  const validateForm = () => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.name.trim()) {
+      newErrors.name = "Nome é obrigatório";
+    }
+
+    if (!formData.email.trim()) {
+      newErrors.email = "E-mail é obrigatório";
+    } else if (!isValidEmail(formData.email)) {
+      newErrors.email = "E-mail inválido";
+    }
+
+    if (!formData.area_atuacao.trim()) {
+      newErrors.area_atuacao = "Área de atuação é obrigatória";
+    }
+
+    if (mode === "create") {
+      if (!formData.password) {
+        newErrors.password = "Senha é obrigatória";
+      } else if (formData.password.length < 8) {
+        newErrors.password = "Senha deve ter no mínimo 8 caracteres";
+      }
+
+      if (formData.password !== formData.password_confirmation) {
+        newErrors.password_confirmation = "As senhas não coincidem";
+      }
+    } else if (mode === "edit" && formData.password) {
+      if (formData.password.length < 8) {
+        newErrors.password = "Senha deve ter no mínimo 8 caracteres";
+      }
+
+      if (formData.password !== formData.password_confirmation) {
+        newErrors.password_confirmation = "As senhas não coincidem";
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  // Submete o formulario
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    const professorData: Partial<Professor> = {
+      name: formData.name,
+      email: formData.email,
+      area_atuacao: formData.area_atuacao,
+    };
+
+    // Adiciona senha apenas se foi preenchida
+    if (formData.password) {
+      professorData.password = formData.password;
+      professorData.password_confirmation = formData.password_confirmation;
+    }
+
+    // Adiciona ID se for edicao
+    if (mode === "edit" && professor) {
+      professorData.id = professor.id;
+    }
+
+    onSave(professorData as Omit<Professor, "id"> | Professor);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm p-4">
+      <div className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-xl border border-stone-200 bg-white shadow-lg">
+        {/* Header do modal */}
+        <div className="flex items-center justify-between border-b border-stone-200 px-4 py-4 sm:px-6">
+          <h2 className="flex items-center gap-2 text-xl font-bold text-stone-900">
+            <GraduationCap className="h-5 w-5 text-teal-600" />
+            {mode === "create" ? "Novo Professor" : "Editar Professor"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-stone-400 hover:text-stone-600 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Formulario */}
+        <form onSubmit={handleSubmit} className="space-y-4 px-4 py-4 sm:px-6 sm:py-6">
+          {/* Nome */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">Nome *</Label>
+            <div className="relative">
+              <UserCircle className="absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 h-5 w-5" />
+              <Input
+                type="text"
+                value={formData.name}
+                onChange={(e) =>
+                  setFormData({ ...formData, name: e.target.value })
+                }
+                className={`pl-10 ${
+                  errors.name ? "border-red-500" : ""
+                }`}
+                placeholder="Nome completo do professor"
+              />
+            </div>
+            {errors.name && (
+              <p className="mt-1 text-xs text-red-500">{errors.name}</p>
+            )}
+          </div>
+
+          {/* E-mail */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">E-mail *</Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 h-5 w-5" />
+              <Input
+                type="email"
+                value={formData.email}
+                onChange={(e) =>
+                  setFormData({ ...formData, email: e.target.value })
+                }
+                className={`pl-10 ${
+                  errors.email ? "border-red-500" : ""
+                }`}
+                placeholder="email@exemplo.com"
+              />
+            </div>
+            {errors.email && (
+              <p className="mt-1 text-xs text-red-500">{errors.email}</p>
+            )}
+          </div>
+
+          {/* Area de Atuacao */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">
+              Área de Atuação *
+            </Label>
+            <div className="relative">
+              <Briefcase className="absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 h-5 w-5" />
+              <Input
+                type="text"
+                value={formData.area_atuacao}
+                onChange={(e) =>
+                  setFormData({ ...formData, area_atuacao: e.target.value })
+                }
+                className={`pl-10 ${
+                  errors.area_atuacao ? "border-red-500" : ""
+                }`}
+                placeholder="Ex: Matemática, Física, Programação"
+              />
+            </div>
+            {errors.area_atuacao && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.area_atuacao}
+              </p>
+            )}
+          </div>
+
+          {/* Senha */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">
+              Senha {mode === "create" ? "*" : "(opcional)"}
+            </Label>
+            <Input
+              type="password"
+              value={formData.password}
+              onChange={(e) =>
+                setFormData({ ...formData, password: e.target.value })
+              }
+              className={errors.password ? "border-red-500" : ""}
+              placeholder="Mínimo 8 caracteres"
+            />
+            {errors.password && (
+              <p className="mt-1 text-xs text-red-500">{errors.password}</p>
+            )}
+          </div>
+
+          {/* Confirmar Senha */}
+          <div>
+            <Label className="mb-1 text-sm text-stone-600">
+              Confirmar Senha {mode === "create" ? "*" : "(opcional)"}
+            </Label>
+            <Input
+              type="password"
+              value={formData.password_confirmation}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  password_confirmation: e.target.value,
+                })
+              }
+              className={
+                errors.password_confirmation ? "border-red-500" : ""
+              }
+              placeholder="Repita a senha"
+            />
+            {errors.password_confirmation && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.password_confirmation}
+              </p>
+            )}
+          </div>
+
+          {/* Botoes */}
+          <div className="flex gap-3 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              className="flex-1 rounded-xl border-stone-300 text-stone-700 hover:bg-stone-50"
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              className="flex-1 rounded-xl bg-teal-600 text-white hover:bg-teal-700"
+            >
+              {mode === "create" ? "Criar" : "Salvar"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/teachers/Teachers.tsx
+++ b/front/src/pages/teachers/Teachers.tsx
@@ -19,377 +19,19 @@ import {
   Plus,
   Pencil,
   Trash2,
-  X,
   Mail,
   UserCircle,
   Briefcase,
-  Sparkles,
 } from "lucide-react";
 import Notification from "@/components/Notification";
 import Loading from "@/components/Loading";
 import { HeroHeader } from "@/components/HeroHeader";
 import { SearchFilter } from "@/components/SearchFilter";
+import { EmptyState } from "@/components/EmptyState";
+import { Button } from "@/components/ui/button";
+import { TeacherFormModal } from "./TeacherFormModal";
+import { DeleteTeacherModal } from "./DeleteTeacherModal";
 
-/* ── palette tokens (inline, no global leak) ────────────────── */
-const palette = {
-  accent: "#0d9488",        // teal-600
-  accentLight: "#ccfbf1",   // teal-100
-  accentSoft: "#f0fdfa",    // teal-50
-  warm: "#f59e0b",          // amber-500
-  warmLight: "#fef3c7",     // amber-100
-  surface: "#fafaf9",       // stone-50
-  cardBg: "#ffffff",
-  textPrimary: "#1c1917",   // stone-900
-  textSecondary: "#78716c", // stone-500
-  border: "#e7e5e4",        // stone-300
-  dangerText: "#dc2626",
-  dangerBg: "#fef2f2",
-};
-
-// Interface para props do modal de formulario
-interface ProfessorFormModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSave: (professor: Omit<Professor, "id"> | Professor) => void;
-  professor: Professor | null;
-  mode: "create" | "edit";
-}
-
-// Componente de modal de formulario para criar/editar professor
-function ProfessorFormModal({
-  isOpen,
-  onClose,
-  onSave,
-  professor,
-  mode,
-}: ProfessorFormModalProps) {
-  const [formData, setFormData] = useState({
-    name: "",
-    email: "",
-    area_atuacao: "",
-    password: "",
-    password_confirmation: "",
-  });
-
-  const [errors, setErrors] = useState<Record<string, string>>({});
-
-  // Atualiza o formulario quando o professor selecionado muda
-  useEffect(() => {
-    if (professor && mode === "edit") {
-      setFormData({
-        name: professor.name,
-        email: professor.email,
-        area_atuacao: professor.area_atuacao,
-        password: "",
-        password_confirmation: "",
-      });
-    } else {
-      setFormData({
-        name: "",
-        email: "",
-        area_atuacao: "",
-        password: "",
-        password_confirmation: "",
-      });
-    }
-    setErrors({});
-  }, [professor, mode, isOpen]);
-
-  // Valida o email
-  const isValidEmail = (email: string) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-  };
-
-  // Valida o formulario
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {};
-
-    if (!formData.name.trim()) {
-      newErrors.name = "Nome é obrigatório";
-    }
-
-    if (!formData.email.trim()) {
-      newErrors.email = "E-mail é obrigatório";
-    } else if (!isValidEmail(formData.email)) {
-      newErrors.email = "E-mail inválido";
-    }
-
-    if (!formData.area_atuacao.trim()) {
-      newErrors.area_atuacao = "Área de atuação é obrigatória";
-    }
-
-    if (mode === "create") {
-      if (!formData.password) {
-        newErrors.password = "Senha é obrigatória";
-      } else if (formData.password.length < 8) {
-        newErrors.password = "Senha deve ter no mínimo 8 caracteres";
-      }
-
-      if (formData.password !== formData.password_confirmation) {
-        newErrors.password_confirmation = "As senhas não coincidem";
-      }
-    } else if (mode === "edit" && formData.password) {
-      if (formData.password.length < 8) {
-        newErrors.password = "Senha deve ter no mínimo 8 caracteres";
-      }
-
-      if (formData.password !== formData.password_confirmation) {
-        newErrors.password_confirmation = "As senhas não coincidem";
-      }
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  // Submete o formulario
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!validateForm()) {
-      return;
-    }
-
-    const professorData: Partial<Professor> = {
-      name: formData.name,
-      email: formData.email,
-      area_atuacao: formData.area_atuacao,
-    };
-
-    // Adiciona senha apenas se foi preenchida
-    if (formData.password) {
-      professorData.password = formData.password;
-      professorData.password_confirmation = formData.password_confirmation;
-    }
-
-    // Adiciona ID se for edicao
-    if (mode === "edit" && professor) {
-      professorData.id = professor.id;
-    }
-
-    onSave(professorData as Omit<Professor, "id"> | Professor);
-  };
-
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
-        {/* Header do modal */}
-        <div className="flex items-center justify-between p-6 border-b border-stone-200">
-          <h2 className="text-xl font-bold text-stone-900 flex items-center gap-2">
-            <GraduationCap className="w-5 h-5" style={{ color: palette.accent }} />
-            {mode === "create" ? "Novo Professor" : "Editar Professor"}
-          </h2>
-          <button
-            onClick={onClose}
-            className="text-stone-400 hover:text-stone-600 transition-colors"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-
-        {/* Formulario */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-4">
-          {/* Nome */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Nome *
-            </label>
-            <div className="relative">
-              <UserCircle className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400 w-5 h-5" />
-              <input
-                type="text"
-                value={formData.name}
-                onChange={(e) =>
-                  setFormData({ ...formData, name: e.target.value })
-                }
-                className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                  errors.name ? "border-red-500" : "border-stone-300"
-                }`}
-                placeholder="Nome completo do professor"
-              />
-            </div>
-            {errors.name && (
-              <p className="text-red-500 text-xs mt-1">{errors.name}</p>
-            )}
-          </div>
-
-          {/* E-mail */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              E-mail *
-            </label>
-            <div className="relative">
-              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400 w-5 h-5" />
-              <input
-                type="email"
-                value={formData.email}
-                onChange={(e) =>
-                  setFormData({ ...formData, email: e.target.value })
-                }
-                className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                  errors.email ? "border-red-500" : "border-stone-300"
-                }`}
-                placeholder="email@exemplo.com"
-              />
-            </div>
-            {errors.email && (
-              <p className="text-red-500 text-xs mt-1">{errors.email}</p>
-            )}
-          </div>
-
-          {/* Area de Atuacao */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Área de Atuação *
-            </label>
-            <div className="relative">
-              <Briefcase className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400 w-5 h-5" />
-              <input
-                type="text"
-                value={formData.area_atuacao}
-                onChange={(e) =>
-                  setFormData({ ...formData, area_atuacao: e.target.value })
-                }
-                className={`w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                  errors.area_atuacao ? "border-red-500" : "border-stone-300"
-                }`}
-                placeholder="Ex: Matemática, Física, Programação"
-              />
-            </div>
-            {errors.area_atuacao && (
-              <p className="text-red-500 text-xs mt-1">{errors.area_atuacao}</p>
-            )}
-          </div>
-
-          {/* Senha */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Senha {mode === "create" ? "*" : "(opcional)"}
-            </label>
-            <input
-              type="password"
-              value={formData.password}
-              onChange={(e) =>
-                setFormData({ ...formData, password: e.target.value })
-              }
-              className={`w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                errors.password ? "border-red-500" : "border-stone-300"
-              }`}
-              placeholder="Mínimo 8 caracteres"
-            />
-            {errors.password && (
-              <p className="text-red-500 text-xs mt-1">{errors.password}</p>
-            )}
-          </div>
-
-          {/* Confirmar Senha */}
-          <div>
-            <label className="block text-sm font-medium text-stone-600 mb-1">
-              Confirmar Senha {mode === "create" ? "*" : "(opcional)"}
-            </label>
-            <input
-              type="password"
-              value={formData.password_confirmation}
-              onChange={(e) =>
-                setFormData({
-                  ...formData,
-                  password_confirmation: e.target.value,
-                })
-              }
-              className={`w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent ${
-                errors.password_confirmation
-                  ? "border-red-500"
-                  : "border-stone-300"
-              }`}
-              placeholder="Repita a senha"
-            />
-            {errors.password_confirmation && (
-              <p className="text-red-500 text-xs mt-1">
-                {errors.password_confirmation}
-              </p>
-            )}
-          </div>
-
-          {/* Botoes */}
-          <div className="flex gap-3 pt-4">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 px-4 py-2 border border-stone-300 rounded-lg text-stone-700 hover:bg-stone-50 font-medium transition-colors"
-            >
-              Cancelar
-            </button>
-            <button
-              type="submit"
-              className="flex-1 px-4 py-2 text-white rounded-lg hover:opacity-90 font-medium transition-opacity"
-              style={{ backgroundColor: palette.accent }}
-            >
-              {mode === "create" ? "Criar" : "Salvar"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-// Interface para props do dialog de confirmacao
-interface DeleteConfirmDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
-  professorName: string;
-}
-
-// Dialog de confirmacao de remocao
-function DeleteConfirmDialog({
-  isOpen,
-  onClose,
-  onConfirm,
-  professorName,
-}: DeleteConfirmDialogProps) {
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-xl max-w-md w-full p-6" style={{ borderColor: palette.border }}>
-        <div className="flex items-center gap-3 mb-4">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: palette.dangerBg }}>
-            <Trash2 className="w-6 h-6" style={{ color: palette.dangerText }} />
-          </div>
-          <h2 className="text-xl font-bold text-stone-900">Confirmar Remoção</h2>
-        </div>
-
-        <p className="text-stone-500 mb-6">
-          Tem certeza que deseja remover o professor{" "}
-          <span className="font-semibold text-stone-900">{professorName}</span>?
-          Esta ação não pode ser desfeita.
-        </p>
-
-        <div className="flex gap-3">
-          <button
-            onClick={onClose}
-            className="flex-1 px-4 py-2 border border-stone-300 rounded-lg text-stone-700 hover:bg-stone-50 font-medium transition-colors"
-          >
-            Cancelar
-          </button>
-          <button
-            onClick={onConfirm}
-            className="flex-1 px-4 py-2 text-white rounded-lg hover:opacity-90 font-medium transition-opacity"
-            style={{ backgroundColor: palette.dangerText }}
-          >
-            Confirmar Remoção
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// Componente principal da pagina de gerenciamento de professores
 export default function Teachers() {
   const [professors, setProfessors] = useState<Professor[]>([]);
   const [loading, setLoading] = useState(true);
@@ -404,12 +46,8 @@ export default function Teachers() {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [professorToDelete, setProfessorToDelete] = useState<Professor | null>(null);
 
-  // Carrega os professores ao montar o componente
-  useEffect(() => {
-    loadProfessors();
-  }, []);
+  useEffect(() => { loadProfessors(); }, []);
 
-  // Funcao para carregar todos os professores
   async function loadProfessors() {
     setLoading(true);
     try {
@@ -425,27 +63,23 @@ export default function Teachers() {
     }
   }
 
-  // Abre o modal de criacao
   function handleCreate() {
     setSelectedProfessor(null);
     setModalMode("create");
     setIsModalOpen(true);
   }
 
-  // Abre o modal de edicao
   function handleEdit(professor: Professor) {
     setSelectedProfessor(professor);
     setModalMode("edit");
     setIsModalOpen(true);
   }
 
-  // Abre o dialog de confirmacao de remocao
   function handleDeleteClick(professor: Professor) {
     setProfessorToDelete(professor);
     setIsDeleteDialogOpen(true);
   }
 
-  // Confirma a remocao do professor
   async function confirmDelete() {
     if (!professorToDelete) return;
 
@@ -454,24 +88,15 @@ export default function Teachers() {
       setIsDeleteDialogOpen(false);
       setProfessorToDelete(null);
 
-      // Recarrega a lista de professores
       await loadProfessors();
-
-      setNotification({
-        message: "Professor removido com sucesso!",
-        type: "success",
-      });
+      setNotification({ message: "Professor removido com sucesso!", type: "success" });
     } catch (_error) {
-      setNotification({
-        message: "Erro ao remover professor",
-        type: "error",
-      });
+      setNotification({ message: "Erro ao remover professor", type: "error" });
       setIsDeleteDialogOpen(false);
       setProfessorToDelete(null);
     }
   }
 
-  // Salva o professor (criacao ou edicao)
   async function handleSave(professorData: Omit<Professor, "id"> | Professor) {
     try {
       if (modalMode === "create") {
@@ -481,13 +106,8 @@ export default function Teachers() {
         await updateProfessor(id, dataToUpdate);
       }
 
-      // Fecha o modal
       setIsModalOpen(false);
-
-      // Recarrega a lista de professores
       await loadProfessors();
-
-      // Mostra notificacao de sucesso
       setNotification({
         message: modalMode === "create"
           ? "Professor criado com sucesso!"
@@ -500,14 +120,10 @@ export default function Teachers() {
         const axiosError = error as { response?: { data?: { message?: string } } };
         errorMessage = axiosError.response?.data?.message || errorMessage;
       }
-      setNotification({
-        message: errorMessage,
-        type: "error",
-      });
+      setNotification({ message: errorMessage, type: "error" });
     }
   }
 
-  // Filtra professores conforme o termo de busca
   const filteredProfessors = professors.filter((professor) => {
     const searchLower = searchTerm.toLowerCase();
     return (
@@ -519,18 +135,6 @@ export default function Teachers() {
 
   return (
     <div className="min-h-[80vh]">
-      {/* ---- scoped keyframes ---- */}
-      <style>{`
-        @keyframes teachers-fade-up {
-          from { opacity: 0; transform: translateY(18px); }
-          to   { opacity: 1; transform: translateY(0); }
-        }
-        .teacher-row {
-          animation: teachers-fade-up .45s cubic-bezier(.22,1,.36,1) both;
-        }
-      `}</style>
-
-      {/* Notificacao */}
       {notification && (
         <Notification
           message={notification.message}
@@ -538,16 +142,12 @@ export default function Teachers() {
           onClose={() => setNotification(null)}
         />
       )}
-
-      {/* ══════ HERO HEADER ══════ */}
       <HeroHeader
         icon={GraduationCap}
         title="Gerenciamento de Professores"
         description="Cadastre, edite e gerencie os professores da plataforma."
       />
-
-      {/* ══════ SEARCH BAR + ADD BUTTON ══════ */}
-      <div className="flex items-center gap-3 mb-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center mb-6">
         <div className="flex-1">
           <SearchFilter
             searchTerm={searchTerm}
@@ -555,63 +155,54 @@ export default function Teachers() {
             placeholder="Buscar por nome, área de atuação ou e-mail..."
           />
         </div>
-        <button
+        <Button
           onClick={handleCreate}
-          className="shrink-0 flex items-center gap-2 bg-teal-600 text-white font-semibold hover:bg-teal-700 transition-colors rounded-xl px-5 h-10"
+          className="shrink-0 rounded-xl bg-teal-600 text-white hover:bg-teal-700"
+          size="lg"
         >
-          <Plus className="w-4 h-4" />
-          Adicionar Professor
-        </button>
+          <Plus className="h-4 w-4" />
+          <span className="hidden sm:inline">Adicionar Professor</span>
+          <span className="sm:hidden">Adicionar</span>
+        </Button>
       </div>
-
-      {/* ══════ TABLE ══════ */}
-      <div
-        className="rounded-2xl border shadow-sm overflow-hidden"
-        style={{ borderColor: palette.border, backgroundColor: palette.cardBg }}
-      >
+      <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
         {loading ? (
           <div className="p-6">
             <Loading />
           </div>
         ) : filteredProfessors.length === 0 ? (
-          /* ── empty state ── */
-          <div className="flex flex-col items-center justify-center py-24 text-center">
-            <div
-              className="mb-5 flex h-20 w-20 items-center justify-center rounded-2xl"
-              style={{ background: palette.accentLight }}
-            >
-              <Sparkles className="w-9 h-9" style={{ color: palette.accent }} />
-            </div>
-            <p className="text-lg font-semibold text-stone-700">
-              {searchTerm
+          <EmptyState
+            icon={GraduationCap}
+            title={
+              searchTerm
                 ? "Nenhum professor encontrado"
-                : "Nenhum professor cadastrado"}
-            </p>
-            <p className="mt-1 text-sm text-stone-400 max-w-xs">
-              {searchTerm
+                : "Nenhum professor cadastrado"
+            }
+            description={
+              searchTerm
                 ? "Tente ajustar o termo de busca."
-                : "Clique em 'Adicionar Professor' para começar."}
-            </p>
-          </div>
+                : "Clique em 'Adicionar Professor' para começar."
+            }
+          />
         ) : (
           <Table>
             <TableHeader>
               <TableRow className="bg-stone-50 hover:bg-stone-50">
                 <TableHead className="font-semibold text-stone-900">
                   <div className="flex items-center gap-2">
-                    <UserCircle className="w-4 h-4" />
+                    <UserCircle className="h-4 w-4" />
                     Nome
                   </div>
                 </TableHead>
-                <TableHead className="font-semibold text-stone-900">
+                <TableHead className="hidden font-semibold text-stone-900 sm:table-cell">
                   <div className="flex items-center gap-2">
-                    <Mail className="w-4 h-4" />
+                    <Mail className="h-4 w-4" />
                     E-mail
                   </div>
                 </TableHead>
-                <TableHead className="font-semibold text-stone-900">
+                <TableHead className="hidden font-semibold text-stone-900 md:table-cell">
                   <div className="flex items-center gap-2">
-                    <Briefcase className="w-4 h-4" />
+                    <Briefcase className="h-4 w-4" />
                     Área de Atuação
                   </div>
                 </TableHead>
@@ -621,36 +212,45 @@ export default function Teachers() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredProfessors.map((professor, i) => (
+              {filteredProfessors.map((professor) => (
                 <TableRow
                   key={professor.id}
-                  className="teacher-row hover:bg-stone-50 transition-colors duration-200"
-                  style={{ animationDelay: `${i * 60}ms` }}
+                  className="hover:bg-stone-50 transition-colors"
                 >
-                  <TableCell className="font-medium text-stone-900">
-                    {professor.name}
+                  <TableCell>
+                    <div>
+                      <span className="font-medium text-sm text-stone-900 sm:text-base">
+                        {professor.name}
+                      </span>
+                      <p className="text-xs text-stone-400 sm:hidden">
+                        {professor.email}
+                      </p>
+                      <p className="text-xs text-stone-400 md:hidden sm:hidden">
+                        {professor.area_atuacao}
+                      </p>
+                    </div>
                   </TableCell>
-                  <TableCell className="text-stone-500">
+                  <TableCell className="hidden text-sm text-stone-500 sm:table-cell">
                     {professor.email}
                   </TableCell>
-                  <TableCell className="text-stone-500">
+                  <TableCell className="hidden text-sm text-stone-500 md:table-cell">
                     {professor.area_atuacao}
                   </TableCell>
                   <TableCell>
-                    <div className="flex items-center justify-center gap-2">
+                    <div className="flex items-center justify-center gap-1 sm:gap-2">
                       <button
                         onClick={() => handleEdit(professor)}
-                        className="p-2 rounded-lg text-stone-400 hover:text-teal-600 hover:bg-teal-50 transition-colors"
+                        className="rounded-lg p-2 text-stone-400 transition-colors hover:bg-teal-50 hover:text-teal-600"
                         title="Editar professor"
                       >
-                        <Pencil className="w-4 h-4" />
+                        <Pencil className="h-4 w-4" />
                       </button>
                       <button
                         onClick={() => handleDeleteClick(professor)}
-                        className="p-2 rounded-lg text-stone-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+                        className="rounded-lg p-2 text-stone-400 transition-colors hover:bg-red-50 hover:text-red-600"
                         title="Remover professor"
                       >
-                        <Trash2 className="w-4 h-4" />
+                        <Trash2 className="h-4 w-4" />
                       </button>
                     </div>
                   </TableCell>
@@ -660,18 +260,14 @@ export default function Teachers() {
           </Table>
         )}
       </div>
-
-      {/* Modal de formulario */}
-      <ProfessorFormModal
+      <TeacherFormModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onSave={handleSave}
         professor={selectedProfessor}
         mode={modalMode}
       />
-
-      {/* Dialog de confirmacao de remocao */}
-      <DeleteConfirmDialog
+      <DeleteTeacherModal
         isOpen={isDeleteDialogOpen}
         onClose={() => {
           setIsDeleteDialogOpen(false);


### PR DESCRIPTION
## Summary
- **12 commits** covering every page in the frontend for responsive design and design system consistency
- Removed all hardcoded `palette` objects with hex colors — replaced with Tailwind utility classes
- Removed all `style={{}}` inline props and `onMouseEnter`/`onMouseLeave` style manipulation
- Split 6 oversized files (427-748 lines) into composable sub-components (all under 300 lines)
- Applied mobile-first responsive design using `sm:`, `md:`, `lg:` breakpoints throughout
- Replaced raw HTML form elements with UI components (`Button`, `Input`, `Label`) across all pages
- Added responsive table columns (hidden on mobile), mobile card views for data tables
- Standardized card pattern: `rounded-xl border border-stone-200 bg-white px-3 py-3 sm:px-5 sm:py-5`
- Standardized typography: `text-sm`/`text-base` body, `text-xl`/`text-2xl` headers

## Pages Changed

| Page | Components Created | Lines Before | Lines After | Build Status |
|------|-------------------|-------------|------------|--------------|
| Activities | 0 | 164 | 164 | ✅ |
| Classes | ClassCard, ClassFormInline | 427 | 257 | ✅ |
| Problems | ProblemFormModal, DeleteConfirmModal | 703 | 226 | ✅ |
| Students | StudentFormModal, DeleteStudentModal, StudentTable | 747 | 246 | ✅ |
| Teachers | TeacherFormModal, DeleteTeacherModal | 685 | 281 | ✅ |
| SubmissionsDetails | StatsCards, SubmissionInfoSection, ErrorSections, TestResultsSection, statusConfig, utils | 699 | 206 | ✅ |
| ActivitiesDetails | SubmissionsHistory, utils | 386 | 258 | ✅ |
| Submissions | 0 | 259 | 232 | ✅ |
| Home | 0 (sub-components fixed) | 281 | 281 | ✅ |
| Login | 0 | 270 | 263 | ✅ |
| ForgotPassword | 0 | 222 | 217 | ✅ |
| ChangePassword | 0 | 233 | 239 | ✅ |
| ResetPassword | 0 | 296 | 289 | ✅ |
| JamStudentView | JamResultsPanel | 452 | 287 | ✅ |
| JamProfessorView | 0 | 320 | 319 | ✅ |
| JamCreate | 0 | 173 | 171 | ✅ |
| JamLobby | 0 | 75 | 74 | ✅ |
| Monitoring | 0 | 114 | 114 | ✅ |
| ClassDetails + tabs | 0 (5 tab files fixed) | 206 | 205 | ✅ |
| Unauthorized | 0 | 55 | 55 | ✅ |

**Total: 18 new component files created, ~7201 → ~4818 lines in main page files**

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors ✅ (verified)
- [ ] `npm run build` succeeds ✅ (verified)
- [ ] Manual test each page at mobile (375px), tablet (768px), and desktop (1280px) widths
- [ ] Verify modals overlay correctly on mobile (fixed positioning, no content push)
- [ ] Verify tables hide appropriate columns on mobile and show sub-info
- [ ] Verify all buttons, inputs, and labels use the design system components
- [ ] No console.error or console.warn from component code

🤖 Generated with [Claude Code](https://claude.com/claude-code)